### PR TITLE
chore: update dpp render link

### DIFF
--- a/website/docs/specification/DigitalProductPassport.md
+++ b/website/docs/specification/DigitalProductPassport.md
@@ -422,7 +422,7 @@ Note - this sample describes the digital product passport payload only - ie the 
 
 |Project|DPP Version|Description|Credential|Rendered View|
 |--|--|--|--|--|
-|AATP |0.1.0|Packaged Meat DPP |[sample DPP VC](../../samples/au-agriculture/vc-dpp-0.1.0-au-meat-product.json) |[DPP VC Viewer](https://web.agtrace.showthething.com/verify?q=%7B%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fagtrace-processor-verifiable-credentials.s3.ap-southeast-2.amazonaws.com%2F9359502000041%2F14713cf0-b81c-497c-a633-985cbb4bd5c4.json%22%7D%7D) |
+|AATP |0.1.0|Packaged Meat DPP |[sample DPP VC](../../samples/au-agriculture/vc-dpp-0.1.0-au-meat-product.json) |[DPP VC Viewer](https://web.agtrace.showthething.com/verify?q=%7B%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fagtrace-processor-verifiable-credentials.s3.ap-southeast-2.amazonaws.com%2F9359502000041%2Fde0ff0c2-cec8-4cca-aa84-fac75c75103c.json%22%7D%7D) |
 
 
 

--- a/website/docs/specification/DigitalProductPassport.md
+++ b/website/docs/specification/DigitalProductPassport.md
@@ -289,9 +289,9 @@ https://vocabulary.uncefact.org/CountryId
 
 ## Schema
 
-|DPP Version|status|JSON-LD Context|JSON Schema|Open API 2.0|
+|DPP Version|status|JSON-LD Context|JSON Schema|
 |--|--|--|--|
-|0.3.0|Raw (not for implementation)|[DPP context](../../schema/digitalProductPassport.v0.3.0.JSONLDContext.jsonld)|[DPP schema](../../schema/digitalProductPassport.v0.3.0.JSONSchema.json)][DPP API](../../schema/digitalProductPassport.v0.3.0.OpenAPISpecification.json)|
+|0.3.0|Raw (not for implementation)|[DPP context](../../schema/digitalProductPassport.v0.3.0.JSONLDContext.jsonld)|[DPP schema](../../schema/digitalProductPassport.v0.3.0.JSONSchema.json)|
 
 ## Sample
 


### PR DESCRIPTION
In this PR, I have removed the DPP API spec from the schema table (see [this comment](https://github.com/uncefact/spec-untp/pull/41#discussion_r1538164337)) and updated the example DPP render viewer link as it was pointing to a stale DPP with bad Transformation Event input links.

**DPP Schema Table**
<img width="1677" alt="Screenshot 2024-03-26 at 11 40 57 am" src="https://github.com/uncefact/spec-untp/assets/60303491/28fc3b0e-d8e3-4a3c-97b0-da4b5f7318ca">

**Example DPP Table**
<img width="1677" alt="Screenshot 2024-03-26 at 11 57 51 am" src="https://github.com/uncefact/spec-untp/assets/60303491/e0568047-3da2-45f1-9981-d7993b2b0c02">