### PR TITLE
Removing an out of place header

### DIFF
--- a/website/docs/specification/Identifiers.md
+++ b/website/docs/specification/Identifiers.md
@@ -27,6 +27,3 @@ One case deserves special mention: a URL encoded in a QR Code. Almost all smartp
 
 
 ## Resolvability
-
-
-## Verifiability 


### PR DESCRIPTION
Verifying an identifiers doesn't make sense, removing this empty header.