### PR TITLE
DPP Context

### DIFF
--- a/untp-v1.jsonld
+++ b/untp-v1.jsonld
@@ -1,0 +1,29 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://uncefact.github.io/issuer-dependent#",
+        "id": "@id",
+        "type": "@type",
+        "UNTPDigitalProductPassportCredential": {
+            "@id": "https://uncefact.github.io/spec-untp/docs/specification/DigitalProductPassport",
+            "@context": {}
+        },
+        "UNTPDigitalProductPassport": {
+            "@id": "https://uncefact.github.io/spec-untp/docs/specification/DigitalProductPassport#sample",
+            "@context": {
+                "product": {
+                    "@id": "https://schema.org/model",
+                    "@type": "https://schema.org/ProductModel"
+                }
+            }
+        },
+        "Product": {
+            "@id": "https://schema.org/ProductModel",
+            "@context": {
+                "modelName": {
+                    "@id": "https://schema.org/model"
+                }
+            }
+        }
+    }
+}

--- a/untp-v1.jsonld
+++ b/untp-v1.jsonld
@@ -24,6 +24,14 @@
                     "@id": "https://schema.org/model"
                 }
             }
+        },
+        "MaterialProvenance": {
+            "@id": "https://vocabulary.uncefact.org/SpecifiedMaterial",
+            "@context": {
+                "hazardous": {
+                    "@id": "https://vocabulary.uncefact.org/applicableHazardousMaterial"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This adds a limited LD context to the published pages. Should be available from `https://uncefact.github.io/untp-v1`. 

It is far from complete and must be further built out, potentially with tooling. Sharing this very early version is also meant to build the team's understanding of working with LD. This includes basing term definitions on UN in combination with other prevalent vocabs. 

Obviously github.io is an unacceptable domain for any of what we do, not least our context. 

Note it merges into `gh-pages` which probably also is not how we want to maintain in the long run. 