### PR TITLE
UNTP context: Re-order alphabetically, create url links, add CC objects

### DIFF
--- a/website/untp-v1.jsonld
+++ b/website/untp-v1.jsonld
@@ -1,37 +1,86 @@
 {
     "@context": {
         "@version": 1.1,
-        "@vocab": "https://uncefact.github.io/issuer-dependent#",
+        "@vocab": "https://www.w3.org/ns/credentials/issuer-dependent#",
         "id": "@id",
         "type": "@type",
-        "UNTPDigitalProductPassportCredential": {
-            "@id": "https://uncefact.github.io/spec-untp/docs/specification/DigitalProductPassport",
-            "@context": {}
+
+        "schema.org": "https://schema.org/",
+        "uncefact-vocab": "https://vocabulary.uncefact.org/",
+        "untp-spec": "https://uncefact.github.io/spec-untp/docs/specification/",
+        "untp-vocab": "https://test.uncefact.org/vocabulary/untp/",
+
+        "ConformityAssessment": {
+          "@id": "untp-spec:ConformityCredential#conformityassessment",
+          "@context": {
+            "@protected": true,
+    
+            "id": "@id",
+            "type": "@type"
+          }
         },
-        "UNTPDigitalProductPassport": {
-            "@id": "https://uncefact.github.io/spec-untp/docs/specification/DigitalProductPassport#sample",
+    
+        "ConformityAttestation": {
+          "@id": "untp-spec:ConformityCredential#conformityattestation",
+          "@context": {
+            "@protected": true,
+    
+            "id": "@id",
+            "type": "@type"
+          }
+        },
+    
+        "ConformityCredential": {
+          "@id": "untp-spec:ConformityCredential",
+          "@context": {
+            "@protected": true,
+    
+            "id": "@id",
+            "type": "@type"
+          }
+        },
+
+        "DigitalProductPassport": {
+            "@id": "untp-spec:DigitalProductPassport#sample",
             "@context": {
                 "product": {
-                    "@id": "https://schema.org/model",
-                    "@type": "https://schema.org/ProductModel"
+                    "@id": "schema.org:model",
+                    "@type": "schema.org:ProductModel"
                 }
             }
         },
-        "Product": {
-            "@id": "https://schema.org/ProductModel",
-            "@context": {
-                "modelName": {
-                    "@id": "https://schema.org/model"
-                }
-            }
+
+        "DigitalProductPassportCredential": {
+            "@id": "untp-spec:DigitalProductPassport",
+            "@context": {}
         },
+        
         "MaterialProvenance": {
-            "@id": "https://vocabulary.uncefact.org/SpecifiedMaterial",
+            "@id": "uncefact-vocab:SpecifiedMaterial",
             "@context": {
                 "hazardous": {
-                    "@id": "https://vocabulary.uncefact.org/applicableHazardousMaterial"
+                    "@id": "uncefact-vocab:applicableHazardousMaterial"
                 }
             }
+        },
+
+        "Product": {
+            "@id": "schema.org:ProductModel",
+            "@context": {
+                "modelName": {
+                    "@id": "schema.org:model"
+                }
+            }
+        },
+
+        "Regulation": {
+          "@id": "untp:ConformityCredential#regulation",
+          "@context": {
+            "@protected": true,
+    
+            "id": "@id",
+            "type": "@type"
+          }
         }
     }
 }


### PR DESCRIPTION
Addresses some discussions in issue: 
#109

@zachzeus @nissimsan I added the base objects for the CC credential and a suggestion to remove the UNTP prefix for the types as this is now defined by the spec/vocab. If we prefer to keep the prefix it can be added back.

Main goal is to add placeholders for the CC stuff since it's what I'm working on. I also suggested an alphabetical order for the defined types and creating url links at the top of the context so we don't have to paste the complete url everywhere.

What is the long term goal for this context?

What will its relationship be with the other contexts:
https://test.uncefact.org/vocabulary/untp/cc/ca-context.jsonld
https://test.uncefact.org/vocabulary/untp/dpp/dpp-context.jsonld
