### PR TITLE
feat: scroll to id

### DIFF
--- a/website/src/components/ScrollToHash/index.tsx
+++ b/website/src/components/ScrollToHash/index.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const headerOffset = 85;
+const timeout = 100;
+
+function ScrollToHash() {
+  const { hash } = useLocation();
+
+  useEffect(() => {
+    // Handle initial load with hash
+    if (hash) {
+      // Small delay to ensure content is loaded
+      setTimeout(() => {
+        const element = document.getElementById(hash.slice(1));
+        if (element) {
+          // Get header height and add some padding
+          const elementPosition = element.getBoundingClientRect().top;
+          const offsetPosition =
+            elementPosition + window.pageYOffset - headerOffset;
+
+          // Scroll to the element
+          window.scrollTo({
+            top: offsetPosition,
+            behavior: "smooth",
+          });
+        }
+      }, timeout);
+    }
+  }, [hash]);
+
+  return null;
+}
+
+export default ScrollToHash;

--- a/website/src/theme/Root.js
+++ b/website/src/theme/Root.js
@@ -1,9 +1,13 @@
 import React from 'react';
+import ScrollToHash from '../components/ScrollToHash';
 import MenuSvgIconsSprite from './svgSprite';
 
 export default function Root({children}) {
-  return <>
-    {children}
-    <MenuSvgIconsSprite/>
-  </>;
+  return (
+    <>
+      <ScrollToHash />
+      {children}
+      <MenuSvgIconsSprite />
+    </>
+  );
 }


### PR DESCRIPTION
This PR adds a smooth scroll navigation component that automatically scrolls to matching element IDs in URLs. For example: clicking a link to /spec-untp/docs/implementations/Software#freshchain will smoothly scroll to the freshchain section.


https://github.com/user-attachments/assets/ced31e8d-4628-4a82-a3e6-8c4fabd45c11

