### PR TITLE
fix(vc)!: require exclusive support for VCDM v2

### DIFF
--- a/website/docs/specification/VerifiableCredentials.md
+++ b/website/docs/specification/VerifiableCredentials.md
@@ -36,12 +36,11 @@ A key design principle that is applicable to decentralized ecosystems such as UN
 
 The VC basic profile is designed to be as simple, lightweight, and interoperable as possible. A conformant implementation
 
-- MUST implement the [W3C VC Data Model v1.1](https://www.w3.org/TR/vc-data-model/) using the JSON-LD Compacted Document Form
-- SHOULD implement the [W3C VC Data Model v2.0](https://www.w3.org/TR/vc-data-model-2.0/) using the JSON-LD Compacted Document Form
+- MUST implement the [W3C VC Data Model v2.0](https://www.w3.org/TR/vc-data-model-2.0/) using the JSON-LD Compacted Document Form
 - MUST implement [W3C VC Bitstring Status List](https://www.w3.org/TR/vc-bitstring-status-list/) for credential status checks including revocation checks
 - MUST implement [W3C-DID-CORE](https://www.w3.org/TR/did-core/) using DID methods defined in [DID methods](#did-methods)
 - MUST implement the enveloping proof mechanism defined in [W3C VC JOSE / COSE](https://www.w3.org/TR/vc-jose-cose/) with JOSE (Section 3.1.1)
-- SHOULD implement the embedded proof mechanism defined in [W3 Data Integrity proof](https://www.w3.org/TR/vc-data-integrity/)
+
 
 ### DID methods
 
@@ -92,4 +91,4 @@ Future versions of this specification will
 
 - Provide richer guidance on did methods via a decision tree that helps to select the right method for the right purpose
 - Provide guidance on selective redaction methods to better support confidentiality goals.
-- Provide timelines for transition between versions of technical specifications (eg when VCDM 2.0 will change from SHOULD support to MUST support)
+- Provide timelines for transition between versions of technical specifications

--- a/website/docs/specification/VerifiableCredentials.md
+++ b/website/docs/specification/VerifiableCredentials.md
@@ -37,7 +37,7 @@ A key design principle that is applicable to decentralized ecosystems such as UN
 The VC basic profile is designed to be as simple, lightweight, and interoperable as possible. A conformant implementation
 
 - MUST implement the [W3C VC Data Model v2.0](https://www.w3.org/TR/vc-data-model-2.0/) using the JSON-LD Compacted Document Form
-- MUST implement [W3C VC Bitstring Status List](https://www.w3.org/TR/vc-bitstring-status-list/) for credential status checks including revocation checks
+- MUST implement [W3C VC Bitstring Status List](https://www.w3.org/TR/vc-bitstring-status-list/) for credential status management including revocation
 - MUST implement [W3C-DID-CORE](https://www.w3.org/TR/did-core/) using DID methods defined in [DID methods](#did-methods)
 - MUST implement the enveloping proof mechanism defined in [W3C VC JOSE / COSE](https://www.w3.org/TR/vc-jose-cose/) with JOSE (Section 3.1.1)
 


### PR DESCRIPTION
This PR seeks to simplify the requirements for Verifiable Credentials within UNTP by requiring exclusive support for [VCDM v2](https://www.w3.org/TR/vc-data-model-2.0/). 

The context for this matter can be found in ticket #262.