### PR TITLE
fix: add missing dependency

### DIFF
--- a/.github/workflows/docs-to-pdf.yml
+++ b/.github/workflows/docs-to-pdf.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - fix/add_missing_dependency
     paths-ignore:
       - "website/static/un-transparency-protocol.pdf"
 
@@ -41,6 +40,7 @@ jobs:
         # but the package only includes type definitions.
         # This step installs fs-extra globally until the package
         # is updated to include it as a proper dependency.
+        # You can track the progress here: https://github.com/jean-humann/docs-to-pdf/pull/484
         run: npm install -g fs-extra
 
       - name: Install dependencies
@@ -49,7 +49,7 @@ jobs:
       - name: Generate PDF
         run: |
           echo "waiting for two minutes for GitHub pages to be deployed..."
-          # sleep 120 && echo "Done!"
+          sleep 120 && echo "Done!"
           npx docs-to-pdf --initialDocURLs="https://uncefact.github.io/spec-untp/docs/about/" \
           --contentSelector="article" \
           --paginationSelector="a.pagination-nav__link.pagination-nav__link--next" \

--- a/.github/workflows/docs-to-pdf.yml
+++ b/.github/workflows/docs-to-pdf.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Generate PDF
         run: |
           echo "waiting for two minutes for GitHub pages to be deployed..."
-          sleep 120 && echo "Done!"
+          # sleep 120 && echo "Done!"
           npx docs-to-pdf --initialDocURLs="https://uncefact.github.io/spec-untp/docs/about/" \
           --contentSelector="article" \
           --paginationSelector="a.pagination-nav__link.pagination-nav__link--next" \
@@ -57,7 +57,8 @@ jobs:
           --excludeURLs="https://uncefact.github.io/spec-untp/docs/about/Meetings,https://uncefact.github.io/spec-untp/docs/about/FAQ" \
           --outputPDFFilename="website/static/un-transparency-protocol.pdf" \
           --coverTitle="UN Transparency Protocol" \
-          --coverImage="https://uncefact.github.io/spec-untp/img/home-hero.jpg"
+          --coverImage="https://uncefact.github.io/spec-untp/img/home-hero.jpg" \
+          --puppeteerArgs="--no-sandbox,--disable-setuid-sandbox"
 
       - name: commit pdf
         run: |

--- a/.github/workflows/docs-to-pdf.yml
+++ b/.github/workflows/docs-to-pdf.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - fix/add_missing_dependency
     paths-ignore:
       - "website/static/un-transparency-protocol.pdf"
 
@@ -34,6 +35,13 @@ jobs:
         with:
           node-version: 18
           cache: yarn
+
+      - name: Install fs-extra
+        # Workaround: docs-to-pdf expects fs-extra at runtime,
+        # but the package only includes type definitions.
+        # This step installs fs-extra globally until the package
+        # is updated to include it as a proper dependency.
+        run: npm install -g fs-extra
 
       - name: Install dependencies
         run: npm install -g docs-to-pdf


### PR DESCRIPTION
This PR adds the missing `fs-extra` dependency and required Puppeteer args, which prevented the pipeline from succeeding and publishing the PDF artefact.

A [PR](https://github.com/jean-humann/docs-to-pdf/pull/484) has been raised to address the issue upstream.

**Docs to PDF**
Workflow run: https://github.com/uncefact/spec-untp/actions/runs/13230989915
Artefact produced: https://github.com/uncefact/spec-untp/commit/f70f859d76df03cf79058bb4880a42dece9fdc7a#diff-b490d7ed59ca3e8e3a79beb07ba889e726ecae899d848e536fd5c8d72c849329

<img width="1552" alt="Screenshot 2025-02-10 at 11 42 10 am" src="https://github.com/user-attachments/assets/f3b8e510-d500-4f3d-aec8-bebaf2a863c7" />
