### PR TITLE
ci: exclude implementation register

### DIFF
--- a/.github/workflows/docs-to-pdf.yml
+++ b/.github/workflows/docs-to-pdf.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - ci/exclude_implementation_register
     paths-ignore:
       - "website/static/un-transparency-protocol.pdf"
 

--- a/.github/workflows/docs-to-pdf.yml
+++ b/.github/workflows/docs-to-pdf.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - ci/exclude_implementation_register
     paths-ignore:
       - "website/static/un-transparency-protocol.pdf"
 

--- a/.github/workflows/docs-to-pdf.yml
+++ b/.github/workflows/docs-to-pdf.yml
@@ -54,6 +54,7 @@ jobs:
           --contentSelector="article" \
           --paginationSelector="a.pagination-nav__link.pagination-nav__link--next" \
           --excludeSelectors=".breadcrumbs,.theme-edit-this-page" \
+          --excludePaths="/docs/implementations/" \
           --excludeURLs="https://uncefact.github.io/spec-untp/docs/about/Meetings,https://uncefact.github.io/spec-untp/docs/about/FAQ" \
           --outputPDFFilename="website/static/un-transparency-protocol.pdf" \
           --coverTitle="UN Transparency Protocol" \


### PR DESCRIPTION
This PR excludes the pages associated with the implementation register from the pdf derived from the website.

Artefact produced: https://github.com/uncefact/spec-untp/blob/d4b01a26cad5332f4ce17c368ef34bc13fedb287/website/static/un-transparency-protocol.pdf

Context: https://uncefact.slack.com/archives/C03L1LDU1ED/p1739249948701249