### PR TITLE
ci: update pdf text size

### DIFF
--- a/.github/workflows/docs-to-pdf.yml
+++ b/.github/workflows/docs-to-pdf.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - ci/update_pdf_text_size
     paths-ignore:
       - "website/static/un-transparency-protocol.pdf"
 
@@ -26,7 +27,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ci/update_pdf_text_size
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
@@ -67,4 +68,4 @@ jobs:
           git config user.email github-actions@github.com
           git add website/static/un-transparency-protocol.pdf
           git commit -m "chore: update PDF file"
-          git push
+          git push origin HEAD:ci/update_pdf_text_size

--- a/.github/workflows/docs-to-pdf.yml
+++ b/.github/workflows/docs-to-pdf.yml
@@ -58,6 +58,7 @@ jobs:
           --outputPDFFilename="website/static/un-transparency-protocol.pdf" \
           --coverTitle="UN Transparency Protocol" \
           --coverImage="https://uncefact.github.io/spec-untp/img/home-hero.jpg" \
+          --cssStyle="body { font-size: 13px !important; } h1 { font-size: 40px !important; } h2 { font-size: 26px !important; } h3 { font-size: 20px !important; } h4 { font-size: 13px !important; }" \
           --puppeteerArgs="--no-sandbox,--disable-setuid-sandbox"
 
       - name: commit pdf

--- a/.github/workflows/docs-to-pdf.yml
+++ b/.github/workflows/docs-to-pdf.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - ci/update_pdf_text_size
     paths-ignore:
       - "website/static/un-transparency-protocol.pdf"
 
@@ -27,7 +26,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
-          ref: ci/update_pdf_text_size
+          ref: main
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
@@ -68,4 +67,4 @@ jobs:
           git config user.email github-actions@github.com
           git add website/static/un-transparency-protocol.pdf
           git commit -m "chore: update PDF file"
-          git push origin HEAD:ci/update_pdf_text_size
+          git push


### PR DESCRIPTION
This PR adjusts the text size within the pdf derived from the website.

**Note**: There are h1 tags being misused on some of the pages, which will be rectified in another PR.

### Example 1 (with h1 being misused)
**Previous**
<img width="1405" alt="Screenshot 2025-02-11 at 8 37 06 pm" src="https://github.com/user-attachments/assets/70d26e8b-f047-4852-94ba-debaa8cf5e1e" />

**New**
<img width="1404" alt="Screenshot 2025-02-11 at 8 38 09 pm" src="https://github.com/user-attachments/assets/d0ffafb5-bc66-437b-8aff-e25496939afa" />

### Example 2

**Previous**
<img width="1405" alt="Screenshot 2025-02-11 at 8 44 48 pm" src="https://github.com/user-attachments/assets/1a720a72-72da-4a92-b4bd-21d493994e4b" />

**New**
<img width="1404" alt="Screenshot 2025-02-11 at 8 45 27 pm" src="https://github.com/user-attachments/assets/fe593281-1ec0-4399-add1-91a42cf50798" />

Artefact produced: [un-transparency-protocol-new-text-size.pdf](https://github.com/user-attachments/files/18748300/un-transparency-protocol.3.pdf)


Context: https://uncefact.slack.com/archives/C03L1LDU1ED/p1739249948701249
