### PR TITLE
Inconsistent Facility title

### DIFF
--- a/website/docs/specification/DigitalFacilityRecord.md
+++ b/website/docs/specification/DigitalFacilityRecord.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 18
-title: Digital Facility Profile
+title: Digital Facility Record
 ---
 
 import Disclaimer from '../\_disclaimer.mdx';


### PR DESCRIPTION
It's called `Digital Facility Record` everywhere else, fixing the title for consistency