### PR TITLE
Remove reference to property `verifiedDIDList` deleted 6 months ago.

### DIFF
--- a/website/docs/specification/DigitalIdentityAnchor.md
+++ b/website/docs/specification/DigitalIdentityAnchor.md
@@ -54,7 +54,7 @@ The outcome is that the subject of the DIA (eg the VAT registered business) can 
 
 * A verifier (eg buyer of an identified product) discovers a DPP for the product and verifies the credential - confirming that the DPP has not been tampered-with, is genuinely issued by party identified by the issuer DID.
 * The DID is resolvable to the DID document which contains a link to the DIA in the DID document `service` end point.
-* Verify the DIA credential and confirm that the DPP issuer DID is contained in the `verifiedDIDList` of the DIA.  
+* Verify the DIA credential and confirm that the DPP issuer DID is the `credentialSubject.id` of the DIA.
 * Confirm that the issuer `did:web` of the DIA (the authoritative register) is on the white list of trust anchors.  
 
 The DIA can also be used for similar trust anchoring purposes such as:


### PR DESCRIPTION
The property `verifiedDIDList` was removed during the initial development of the DIA after [@PatStLouis recommended sticking with just the `credentialSubject.id` ](https://github.com/uncefact/spec-untp/pull/200#discussion_r1829741129). This reference remained and confuses readers (like me :) ).

One related question (not blocking this PR): AIUI, the subject of the DIA should be the DID of the issuer of the DPP/DCC (as outlined originally in https://github.com/uncefact/spec-untp/issues/56 but also [now in the `did:webvh` spec](https://identity.foundation/didwebvh/v1.0/#the-whois-use-case)). Although we are doing so here by ensuring the DIA.credentialSubject.id is the did of the DPP/DCC issuer, we also appear to be mixing types. That is, in the DPP, the issuer did is a `CredentialIssuer`, whereas here in the DIA, the same id has a type `RegisteredIdentity`. These two types have different properties, for example, `RegisteredIdentity` has the `registrationScopeList`. So when putting the data together in a graph, we'll get a single node which has multiple types. It's not clear to me whether this may be an issue later down the track.

My initial thought was that the DIA `credentialSubject` should **be a** `CredentialIssuer`, which would work for three of the other properties currently on `RegisteredIdentity` (`name`, `registeredId` and `idScheme`, which are all part of the `CredentialIssuer.alsoKnownAs`), but not `registerType` nor `registrationScopeList`, which really sound like properties of the registration organisation's DID and the certifier DID respectively? (That is, the DIA issuer's DID, would have some way of getting that the register type, rather than including it in the DIA for the UNTP DPP/DCC, while, for example, a DCC issuer's DID would have some way of proving the scope that they are allowed to attest). It seems that the DigitalIdentityAnchor is trying to be used for more than identity anchoring, which may need to be split out longer-term.



