### PR TITLE
fix: skip validation of secondary instances without context

### DIFF
--- a/.github/actions/validate-jargon-artefacts/src/config.js
+++ b/.github/actions/validate-jargon-artefacts/src/config.js
@@ -1,0 +1,14 @@
+const JARGON_INSTANCES_TO_VALIDATE = [
+    'DigitalConformityCredential_instance',
+    'DigitalProductPassport_instance',
+    'DigitalTraceabilityEvent_instance',
+    'DigitalIdentityAnchor_instance',
+    'DigitalFacilityRecord_instance'
+];
+
+const JARGON_CONTEXT_IRI_PREFIX = 'https://test.uncefact.org/vocabulary/untp/';
+
+module.exports = {
+    JARGON_INSTANCES_TO_VALIDATE,
+    JARGON_CONTEXT_IRI_PREFIX,
+}

--- a/.github/actions/validate-jargon-artefacts/src/contextValidation.js
+++ b/.github/actions/validate-jargon-artefacts/src/contextValidation.js
@@ -62,8 +62,8 @@ async function validateContextInCredential(rawArtefactData, jsonldContext) {
       // Replace the deployed @context IRI (that is, the eventual IRI at which the context will be
       // published when the deploy completes) with the Jargon context IRI where we know
       // it is published right now.
-      instanceJson['@context'] = context.map(context =>
-          context.includes(JARGON_CONTEXT_IRI_PREFIX) ? jsonldContext.url : context
+      instanceJson['@context'] = context.map(c =>
+          c.startsWith(JARGON_CONTEXT_IRI_PREFIX) ? jsonldContext.url : c
         );
       }
     }

--- a/.github/actions/validate-jargon-artefacts/src/contextValidation.js
+++ b/.github/actions/validate-jargon-artefacts/src/contextValidation.js
@@ -2,6 +2,7 @@ const core = require('@actions/core');
 const jsonld = require('jsonld');
 const { splitSchemasAndInstances } = require('./schemaValidation');
 const { fetchArtefactData } = require('./utils');
+const { JARGON_INSTANCES_TO_VALIDATE, JARGON_CONTEXT_IRI_PREFIX } = require('./config');
 
 /**
  * Validate JSON-LD context
@@ -29,15 +30,41 @@ async function validateContext(jsonldContext) {
 /**
  * Validate JSON-LD context in credentials
  * @param rawArtefactData is an array of JSON schemas and instances
+ * @param jsonldContext is the context object provided by Jargon
  * @returns { valid: boolean }
  */
-async function validateContextInCredential(rawArtefactData) {
+async function validateContextInCredential(rawArtefactData, jsonldContext) {
   const { instances } = splitSchemasAndInstances(rawArtefactData);
   const instanceFileNames = Object.keys(instances);
 
-  // Fetch all instances in parallel
-  const fetchedInstances = await Promise.all(instanceFileNames.map(async instanceFileName => {
+  // Filter out secondary instances that lack @context.
+  const mainInstanceFileNames = instanceFileNames.filter(instanceFileName =>
+    JARGON_INSTANCES_TO_VALIDATE.some(validInstance => instanceFileName.includes(validInstance))
+  );
+
+  if (!mainInstanceFileNames.length) {
+    core.info(`
+      No permitted sample instances found for JSON-LD expansion. 
+      Ensure the instance file name is present in JARGON_INSTANCES_TO_VALIDATE. 
+      Current JARGON_INSTANCES_TO_VALIDATE: ${JARGON_INSTANCES_TO_VALIDATE.join(', ')}
+    `);
+    return { valid: false };
+  }
+
+  // Fetch all permitted instances in parallel
+  const fetchedInstances = await Promise.all(mainInstanceFileNames.map(async instanceFileName => {
     const instanceJson = await fetchArtefactData(instances[instanceFileName]);
+
+    if (instanceJson && jsonldContext && JARGON_CONTEXT_IRI_PREFIX) {
+      const context = instanceJson['@context'];
+
+      if(context && Array.isArray(context) && jsonldContext.url) {
+      // Replace the deployed @context IRI with the Jargon context IRI
+      instanceJson['@context'] = context.map(context =>
+          context.includes(JARGON_CONTEXT_IRI_PREFIX) ? jsonldContext.url : context
+        );
+      }
+    }
 
     return {
       fileName: instanceFileName,

--- a/.github/actions/validate-jargon-artefacts/src/contextValidation.js
+++ b/.github/actions/validate-jargon-artefacts/src/contextValidation.js
@@ -59,7 +59,9 @@ async function validateContextInCredential(rawArtefactData, jsonldContext) {
       const context = instanceJson['@context'];
 
       if(context && Array.isArray(context) && jsonldContext.url) {
-      // Replace the deployed @context IRI with the Jargon context IRI
+      // Replace the deployed @context IRI (that is, the eventual IRI at which the context will be
+      // published when the deploy completes) with the Jargon context IRI where we know
+      // it is published right now.
       instanceJson['@context'] = context.map(context =>
           context.includes(JARGON_CONTEXT_IRI_PREFIX) ? jsonldContext.url : context
         );

--- a/.github/actions/validate-jargon-artefacts/src/index.js
+++ b/.github/actions/validate-jargon-artefacts/src/index.js
@@ -30,7 +30,7 @@ async function validateJargonArtefacts(jargonArtefact) {
 
       // Validate JSON-LD context in credentials
       core.info('Validating context in credentials...');
-      validationResult.validateContextInCredentialResult = await validateContextInCredential(rawArtefactData);
+      validationResult.validateContextInCredentialResult = await validateContextInCredential(rawArtefactData, jsonldContext);      
       core.info('Context in credentials validation complete.');
     }
 


### PR DESCRIPTION
This PR fixes #313 and also addresses a secondary issue that was hidden by the primary problem.

## Primary Issue: Validation Pipeline Validating Too Much

### Context

As described in #313, the validation pipeline was incorrectly validating all instances in the payload, not just the primary sample instance. Secondary instances lacking a `@context` caused the pipeline to fail when the JSON-LD processor attempted to expand them.

### Fix

I've introduced a `JARGON_INSTANCES_TO_VALIDATE` variable that explicitly lists which sample instance names should be validated.

The code now filters the payload to validate only those named instances, ignoring all others within the JSON-LD expansion step. 

This approach was chosen because:
- The instance order is not guaranteed.
- There is no identifier marking the “primary” instance.
- The primary instance’s name is user-defined and not derived from the domain name.

While I considered making this configurable via an environment variable, I decided to keep it under version control to avoid accidental or unwanted changes.


## Secondary Issue: Unable to Fetch Context

### Context

Even after isolating the primary instance, the JSON-LD validation step failed because it couldn’t fetch the remote UNTP context.

This was due to the context file not being published at the specified IRI:
- IRI is set to `https://test.uncefact.org/vocabulary/untp/{{CREDENTIAL_ACRONYM}}/{{version}}/` as per domain settings in Jargon.
- However, per our updated [release workflow](https://github.com/uncefact/spec-untp/issues/303), we no longer release directly to `test.uncefact.org/vocabulary/untp/`, we now publish the context files to this repository, validate the artifacts in the pipeline, and then publish to `test.uncefact.org/vocabulary/untp/`.

### Fix

I've introduced a `JARGON_CONTEXT_IRI_PREFIX` variable set to `https://test.uncefact.org/vocabulary/untp/` to detect and replace the IRI.

The code now reads the @context array and rewrites any IRI matching that prefix to use the Jargon-hosted context file provided in the payload.


The pipeline works as expected and has been tested with the available payloads from previous [failed workflows](https://github.com/uncefact/spec-untp/actions/workflows/jargon-webhooks.yml).