### PR TITLE
feat: add retrieval instructions for ontologies

### DIFF
--- a/website/docs/specification/ConformityCredential.md
+++ b/website/docs/specification/ConformityCredential.md
@@ -27,6 +27,16 @@ Digital Conformity Credential version 0.5.0 release artifacts can be used for pi
 
 Latest development versions are used to reflect lessons learned from pilots but should not be used for either pilot testing or production purposes. 
 
+### Ontology 
+The ontology for the Conformity Credential is available in JSON-LD format and can be retrieved via content negotiation from:
+
+[https://test.uncefact.org/vocabulary/untp/dcc/0/](https://test.uncefact.org/vocabulary/untp/dcc/0/)
+
+  Example:
+  ```bash
+  curl https://test.uncefact.org/vocabulary/untp/dcc/0/ -H 'Accept: application/ld+json'
+  ```
+
 ### Version History
 
 History of releases is available from the **[Version history](https://test.uncefact.org/vocabulary/untp/dcc/0/versions)** page.

--- a/website/docs/specification/ConformityCredential.md
+++ b/website/docs/specification/ConformityCredential.md
@@ -28,7 +28,7 @@ Digital Conformity Credential version 0.5.0 release artifacts can be used for pi
 Latest development versions are used to reflect lessons learned from pilots but should not be used for either pilot testing or production purposes. 
 
 ### Ontology 
-The ontology for the Conformity Credential is available in JSON-LD format and can be retrieved via content negotiation from:
+The ontology for the Digital Conformity Credential is available in JSON-LD format and can be retrieved via content negotiation from:
 
 [https://test.uncefact.org/vocabulary/untp/dcc/0/](https://test.uncefact.org/vocabulary/untp/dcc/0/)
 

--- a/website/docs/specification/DigitalFacilityRecord.md
+++ b/website/docs/specification/DigitalFacilityRecord.md
@@ -27,6 +27,16 @@ Version 0.5.0 release artifacts can be used for pilot testing.
 
 Latest development versions are used to reflect lessons learned from pilots but should not be used for either pilot testing or production purposes. 
 
+### Ontology
+The ontology for the Digital Facility Record is available in JSON-LD format and can be retrieved via content negotiation from:
+
+[https://test.uncefact.org/vocabulary/untp/dfr/0/](https://test.uncefact.org/vocabulary/untp/dfr/0/)
+
+  Example:
+  ```bash
+  curl https://test.uncefact.org/vocabulary/untp/dfr/0/ -H 'Accept: application/ld+json'
+  ```
+
 ### Version History
 
 History of releases is available from the **[Version history](https://test.uncefact.org/vocabulary/untp/dfr/0/versions)** page.

--- a/website/docs/specification/DigitalIdentityAnchor.md
+++ b/website/docs/specification/DigitalIdentityAnchor.md
@@ -28,6 +28,16 @@ Latest development versions are used to reflect lessons learned from pilots but 
 * [JSON Schema (credentialSubject only)](https://jargon.sh/user/unece/DigitalIdentityAnchor/v/0.2.1/artefacts/jsonSchemas/RegisteredIdentity.json?class=RegisteredIdentity)
 * [Sample Instance](https://test.uncefact.org/vocabulary/untp/dia/untp-dia-instance-0.2.1.json)
 
+### Ontology
+The ontology for the Digital Identity Anchor is available in JSON-LD format and can be retrieved via content negotiation from:
+
+[https://test.uncefact.org/vocabulary/untp/dia/0/](https://test.uncefact.org/vocabulary/untp/dia/0/)
+
+  Example:
+  ```bash
+  curl https://test.uncefact.org/vocabulary/untp/dia/0/ -H 'Accept: application/ld+json'
+  ```
+
 ### Sample Credential 
 
 |URL|QR|Description|

--- a/website/docs/specification/DigitalProductPassport.md
+++ b/website/docs/specification/DigitalProductPassport.md
@@ -27,6 +27,16 @@ Version 0.5.0 release artifacts can be used for pilot testing.
 
 Latest development versions are used to reflect lessons learned from pilots but should not be used for either pilot testing or production purposes. 
 
+### Ontology
+The ontology for the Digital Product Passport is available in JSON-LD format and can be retrieved via content negotiation from:
+
+[https://test.uncefact.org/vocabulary/untp/dpp/0/](https://test.uncefact.org/vocabulary/untp/dpp/0/)
+
+  Example:
+  ```bash
+  curl https://test.uncefact.org/vocabulary/untp/dpp/0/ -H 'Accept: application/ld+json'
+  ```
+
 ### Version History
 
 History of releases is available from the **[Version history](https://test.uncefact.org/vocabulary/untp/dpp/0/versions)** page.

--- a/website/docs/specification/DigitalTraceabilityEvents.md
+++ b/website/docs/specification/DigitalTraceabilityEvents.md
@@ -27,6 +27,16 @@ Version 0.5.0 release artifacts can be used for pilot testing.
 
 Latest development versions are used to reflect lessons learned from pilots but should not be used for either pilot testing or production purposes. 
 
+### Ontology
+The ontology for Digital Traceability Events is available in JSON-LD format and can be retrieved via content negotiation from:
+
+[https://test.uncefact.org/vocabulary/untp/dte/0/](https://test.uncefact.org/vocabulary/untp/dte/0/)
+
+  Example:
+  ```bash
+  curl https://test.uncefact.org/vocabulary/untp/dte/0/ -H 'Accept: application/ld+json'
+  ```
+
 ### Version History
 
 History of releases is available from the **[Version history](https://test.uncefact.org/vocabulary/untp/dte/0/versions)** page.


### PR DESCRIPTION
This PR fixes #67 by extending the documentation for each UNTP data model to include the location of its ontology and instructions for retrieval.