### PR TITLE
chore: add svc instance name

### DIFF
--- a/.github/actions/validate-jargon-artefacts/src/config.js
+++ b/.github/actions/validate-jargon-artefacts/src/config.js
@@ -1,4 +1,5 @@
 const JARGON_INSTANCES_TO_VALIDATE = [
+    'ConformitySchemeVocabulary_instance',
     'DigitalConformityCredential_instance',
     'DigitalProductPassport_instance',
     'DigitalTraceabilityEvent_instance',


### PR DESCRIPTION
This PR incorporates the Sustainability Vocabulary (SVC) name into the Jargon Artefact validation configuration, enabling validation of the sample document within the domain using the JSON-LD processor (refer to PR #359).