### PR TITLE
chore: update slack link

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -4,6 +4,9 @@
 const lightCodeTheme = require('prism-react-renderer').themes.github;
 const darkCodeTheme = require('prism-react-renderer').themes.dracula;
 
+const slackLink =
+  'https://join.slack.com/t/uncefact/shared_invite/zt-1d7hd0js1-sS1Xgk8DawQD9VgRvy1QHQ';
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'UN Transparency Protocol',
@@ -62,8 +65,7 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
-      slackLink:
-        'https://join.slack.com/t/uncefact/shared_invite/zt-1d7hd0js1-sS1Xgk8DawQD9VgRvy1QHQ',
+      slackLink,
       mailingListLink: 'https://groups.google.com/g/transparency-uncefact',
       colorMode: {
         disableSwitch: true,
@@ -94,7 +96,7 @@ const config = {
             position: 'right',
           },
           {
-            href: 'https://app.slack.com/client/T03KNUD7LHZ/C05R8DD2AKZ',
+            href: slackLink,
             position: 'right',
             html: '<svg class="icon icon-slack"><use xlink:href="#slack"></use></svg><span class="menu-item-name">Slack</span>',
             className: 'navbar-slack-link',


### PR DESCRIPTION
This PR updates the Slack link to improve the user experience and consolidates related configuration.

Previously, two separate links were used: one that led directly to the Slack client (which failed for unauthenticated users) and another that served as an invite link. This PR consolidates both into a single variable `slackLink` pointing to the shared invite URL:

https://join.slack.com/t/uncefact/shared_invite/zt-1d7hd0js1-sS1Xgk8DawQD9VgRvy1QHQ

This link handles both new and existing users gracefully, where unauthenticated users are directed to sign up or join the workspace, while authenticated users are taken directly to the appropriate channel.