### PR TITLE
fix: handle empty domain instances gracefully and improve validation reporting

### DIFF
--- a/.github/actions/validate-jargon-artefacts/src/index.js
+++ b/.github/actions/validate-jargon-artefacts/src/index.js
@@ -23,6 +23,7 @@ async function validateJargonArtefacts(jargonArtefact) {
     const { jsonSchemas: rawArtefactData = [], jsonldContext } = jargonArtefact.artefacts;
     const validationResult = {};
     core.info(`Json Schemas: ${JSON.stringify(rawArtefactData)}`);
+
     if (rawArtefactData && rawArtefactData.length) {
       core.info('Validating sample credentials against schemas...');
       validationResult.validateCredentialsResult = await validateCredentialsSchemas(rawArtefactData);
@@ -30,8 +31,12 @@ async function validateJargonArtefacts(jargonArtefact) {
 
       // Validate JSON-LD context in credentials
       core.info('Validating context in credentials...');
-      validationResult.validateContextInCredentialResult = await validateContextInCredential(rawArtefactData, jsonldContext);      
+      validationResult.validateContextInCredentialResult = await validateContextInCredential(rawArtefactData, jsonldContext);
       core.info('Context in credentials validation complete.');
+    } else {
+      core.warning(
+        'No JSON schemas or sample instances in the Jargon payload. Skipping schema validation and JSON-LD expansion for sample instances.'
+      );
     }
 
     // Validate JSON-LD context
@@ -46,7 +51,14 @@ async function validateJargonArtefacts(jargonArtefact) {
     const resultOutput = getValidationResultOutput(validationResult);
 
     core.setOutput('validation-result', resultOutput);
-    core.info('\nJargon artefacts validation complete.');
+
+    if (resultOutput === 'Failed') {
+      core.setFailed(
+        'One or more Jargon artefact validations reported a failure. Please check the logs for details.'
+      );
+    } else {
+      core.info('\nJargon artefacts validation: Passed.');
+    }
   } catch (error) {
     core.setFailed(`Error validating Jargon artefacts: ${error.message}`);
   }

--- a/.github/actions/validate-jargon-artefacts/src/utils.js
+++ b/.github/actions/validate-jargon-artefacts/src/utils.js
@@ -16,15 +16,15 @@ async function fetchArtefactData (url) {
 }
 
 function getValidationResultOutput({ validateCredentialsResult, validateContextInCredentialResult, validateContextResult }) {
-  if (validateCredentialsResult.valid !== undefined && validateCredentialsResult.valid === false) {
+  if (validateCredentialsResult && validateCredentialsResult.valid === false) {
     return 'Failed';
   }
 
-  if (validateContextInCredentialResult.valid !== undefined && validateContextInCredentialResult.valid === false) {
+  if (validateContextInCredentialResult && validateContextInCredentialResult.valid === false) {
     return 'Failed';
   }
 
-  if (validateContextResult.valid !== undefined && validateContextResult.valid === false) {
+  if (validateContextResult && validateContextResult.valid === false) {
     return 'Failed';
   }
 


### PR DESCRIPTION
This PR resolves an issue in the Jargon Artefact Validation workflow, where an error was thrown and validation incorrectly failed when a Jargon payload lacked sample instances in the domain. This affected artefacts, such as the [Sustainability Vocabulary domain](https://jargon.sh/user/unece/SustainabilityVocabulary), which primarily define a JSON-LD context and vocabulary.

The updated action now checks if the sample instance payload is empty. If it is, schema validation and credential context validation are skipped, and a warning is logged to indicate these steps were bypassed.

The internal logic for determining the overall validation result has been improved to handle cases where specific validation steps, like sample instance validation, are not executed, preventing errors.

The action now passes if only non-sample instance-related validations are performed and succeed (e.g. validating the untp-core domain).

## Example
``` bash
docker run --rm -e INPUT_JARGON-WEBHOOK-PAYLOAD='{
  "action": { "name": "onSnapshot", "type": "snapshot" },
  "artefacts": {
    "dataModel": {
      "fileName": "unece_untp-core_dataModel.svg",
      "url": "https://jargon.sh/user/unece/untp-core/s/4/artefacts/diagram/render.svg?light=true"
    },
    "jsonSchemas": [],
    "jsonldContext": {
      "fileName": "unece_untp-core_jsonldContext.json",
      "url": "https://jargon.sh/user/unece/untp-core/s/4/artefacts/jsonldContexts/untp-core.jsonld?class=untp-core"
    },
    "jsonldVocab": {
      "fileName": "unece_untp-core_jsonld.json",
      "url": "https://jargon.sh/user/unece/untp-core/s/4/artefacts/jsonld/render.jsonld"
    },
    "openapiSpec": {
      "fileName": "unece_untp-core_openapi.json",
      "url": "https://jargon.sh/user/unece/untp-core/s/4/artefacts/openapi/render.json"
    },
    "readme": {
      "fileName": "unece_untp-core_readme.md",
      "url": "https://jargon.sh/user/unece/untp-core/s/4/artefacts/readme/render.md"
    }
  },
  "domain": {
    "account": "unece",
    "name": "untp-core",
    "url": "https://jargon.sh/user/unece/untp-core"
  },
  "settings": {
    "jsonld": {
      "generate": true,
      "prefix": "untp-core",
      "uri": "https://test.uncefact.org/vocabulary/untp/core/{{version}}/"
    }
  },
  "snapshot": {
    "description": "Sync domain with spec-untp repo (with webhook configured..)",
    "index": 4,
    "url": "https://jargon.sh/user/unece/untp-core/s/4/editor"
  }
}
' validate-jargon-artefacts
```

## Result
``` bash
Validating Jargon artefacts...
Json Schemas: []
::warning::No JSON schemas or sample instances in the Jargon payload. Skipping schema validation and JSON-LD expansion for sample instances.


Json LD context: {"fileName":"unece_untp-core_jsonldContext.json","url":"https://jargon.sh/user/unece/untp-core/s/4/artefacts/jsonldContexts/untp-core.jsonld?class=untp-core"}
Validating context...
Context validation results: passed.
Context validation complete.
{
  "validateContextResult": {
    "valid": true
  }
}

::set-output name=validation-result::Passed

Jargon artefacts validation: Passed.
```