### PR TITLE
chore: sync untp-coredata model with Jargon snapshot 7

### DIFF
--- a/data-models/untp-core/vocabulary.jsonld
+++ b/data-models/untp-core/vocabulary.jsonld
@@ -239,7 +239,7 @@
         }
       ],
       "rdfs:comment": [
-        "The W3C DID of the issuer - should be a did:web or did:tdw",
+        "The W3C DID of the issuer - should be a did:web or did:webvh",
         "The globally unique ID of the party as a URI, ideally as a resolvable ID. ",
         "The globally unique identifier of the registration scheme. The scheme should be registered and discoverable from vocabulary.uncefact.org/identifierSchemes",
         "The globally unique URI representing the specific classifier value",


### PR DESCRIPTION
Update the description of CredentialIssuer.id since did:tdw was renamed to did:webvh.
See https://jargon.sh/user/unece/untp-core/issue/1