### PR TITLE
Fix `mimeType` and `unitOfMeasure` external code table links so they concatenate with values

### DIFF
--- a/data-models/untp-core/artefacts/context.jsonld
+++ b/data-models/untp-core/artefacts/context.jsonld
@@ -371,7 +371,7 @@
                   "@type": "@vocab",
                   "@context": {
                     "@protected": true,
-                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode"
+                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode#"
                   }
                 }
               }
@@ -390,7 +390,7 @@
                   "@type": "@vocab",
                   "@context": {
                     "@protected": true,
-                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode"
+                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode#"
                   }
                 }
               }
@@ -409,7 +409,7 @@
                   "@type": "@vocab",
                   "@context": {
                     "@protected": true,
-                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode"
+                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode#"
                   }
                 }
               }
@@ -428,7 +428,7 @@
                   "@type": "@vocab",
                   "@context": {
                     "@protected": true,
-                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode"
+                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode#"
                   }
                 }
               }
@@ -447,7 +447,7 @@
                   "@type": "@vocab",
                   "@context": {
                     "@protected": true,
-                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode"
+                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode#"
                   }
                 }
               }
@@ -568,7 +568,7 @@
                   "@type": "@vocab",
                   "@context": {
                     "@protected": true,
-                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode"
+                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode#"
                   }
                 }
               }
@@ -637,7 +637,7 @@
                   "@type": "@vocab",
                   "@context": {
                     "@protected": true,
-                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode"
+                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode#"
                   }
                 }
               }
@@ -714,7 +714,7 @@
                   "@type": "@vocab",
                   "@context": {
                     "@protected": true,
-                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode"
+                    "@vocab": "https://vocabulary.uncefact.org/UnitMeasureCode#"
                   }
                 }
               }
@@ -801,7 +801,7 @@
               "@type": "@vocab",
               "@context": {
                 "@protected": true,
-                "@vocab": "https://mimetype.io/all-types"
+                "@vocab": "https://mimetype.io/"
               }
             },
             "file": {


### PR DESCRIPTION
Update `mimeType` codetable link, removing `allTypes` as the external examples follow the pattern `https://mimetype.io/application/atom+xml` so the join of the mimeType is just with the root address.
Similarly, update unitOfMeasure codetable link, appending a `#` since the external examples follow the pattern `https://vocabulary.uncefact.org/UnitMeasureCode#10`

Note: Jargon uses the URL both for concatenating with a value for an ID and for displaying to the user as the link where they can see all values, but it can't work for both always. This change gives priority to the former (valid and usable jsonld, with possibly incorrect link in JSONSchema description to users). See https://github.com/jargon-sh/issues/issues/52