### PR TITLE
fix: use jsonld.toRDF for stricter validation

### DIFF
--- a/.github/actions/validate-jargon-artefacts/src/contextValidation.js
+++ b/.github/actions/validate-jargon-artefacts/src/contextValidation.js
@@ -80,8 +80,9 @@ async function validateContextInCredential(rawArtefactData, jsonldContext) {
     await Promise.all(
       fetchedInstances.map(async ({ json, url }) => {
         core.info(`Validating "${url}"`);
-        return jsonld.expand(json, { safe: true });
-      })
+        // Expands the document and converts it to RDF. See issue https://github.com/uncefact/spec-untp/issues/369#issuecomment-2878856840
+        return jsonld.toRDF(json, { safe: true })        
+      }) 
     );
 
     core.info('Context in credentials validation results: passed.');


### PR DESCRIPTION
This PR addresses the issue described in issue #369 by enforcing stricter validation when expanding documents.

I've swapped `jsonld.expand` for `jsonld.toRDF` as the expansion method is allowing errors to slip through (see issue [#570](https://github.com/digitalbazaar/jsonld.js/issues/570)), but are not when using the toRDF method (see issue [#369](https://github.com/uncefact/spec-untp/issues/369#issuecomment-2878387214)).

The toRDF method first expands the document in safe mode (using the options passed in to the toRDF method) and then converts the expanded document to RDF (see code [here](https://github.com/digitalbazaar/jsonld.js/blob/71656073c2abe14b2538215ec8592cd9548b7a35/lib/jsonld.js#L668)).

### Example
``` bash
docker run --rm -e INPUT_JARGON-WEBHOOK-PAYLOAD='{"action":{"name":"onSnapshot","type":"snapshot"},"artefacts":{"dataModel":{"fileName":"unece_DigitalProductPassport_dataModel.svg","url":"https://jargon.sh/user/unece/DigitalProductPassport/s/0/artefacts/diagram/render.svg?light=true"},"jsonSchemas":[{"fileName":"unece_DigitalProductPassport_DigitalProductPassport_jsonSchema.json","url":"https://jargon.sh/user/unece/DigitalProductPassport/s/0/artefacts/jsonSchemas/DigitalProductPassport.json?class=DigitalProductPassport"},{"fileName":"unece_DigitalProductPassport_DigitalProductPassport_instance_jsonSchema.json","url":"https://jargon.sh/user/unece/DigitalProductPassport/s/0/artefacts/jsonSchemas/DigitalProductPassport_instance.json?class=DigitalProductPassport_instance"},{"fileName":"unece_DigitalProductPassport_ProductPassport_jsonSchema.json","url":"https://jargon.sh/user/unece/DigitalProductPassport/s/0/artefacts/jsonSchemas/ProductPassport.json?class=ProductPassport"},{"fileName":"unece_DigitalProductPassport_ProductPassport_instance_jsonSchema.json","url":"https://jargon.sh/user/unece/DigitalProductPassport/s/0/artefacts/jsonSchemas/ProductPassport_instance.json?class=ProductPassport_instance"}],"jsonldContext":{"fileName":"unece_DigitalProductPassport_jsonldContext.json","url":"https://jargon.sh/user/unece/DigitalProductPassport/s/0/artefacts/jsonldContexts/DigitalProductPassport.jsonld?class=DigitalProductPassport"},"jsonldVocab":{"fileName":"unece_DigitalProductPassport_jsonld.json","url":"https://jargon.sh/user/unece/DigitalProductPassport/s/0/artefacts/jsonld/render.jsonld"},"openapiSpec":{"fileName":"unece_DigitalProductPassport_openapi.json","url":"https://jargon.sh/user/unece/DigitalProductPassport/s/0/artefacts/openapi/render.json"},"readme":{"fileName":"unece_DigitalProductPassport_readme.md","url":"https://jargon.sh/user/unece/DigitalProductPassport/s/0/artefacts/readme/render.md"}},"domain":{"account":"unece","name":"DigitalProductPassport","url":"https://jargon.sh/user/unece/DigitalProductPassport"},"settings":{"jsonld":{"generate":true,"prefix":"untp-dpp","uri":"[https://test.uncefact.org/vocabulary/untp/dpp/{{version}}/](https://test.uncefact.org/vocabulary/untp/dpp/%7B%7Bversion%7D%7D/)"}},"snapshot":{"description":"Update `ProductPassport.traceabilityInformation` to be an array. As per https://github.com/uncefact/spec-untp/issues/190","index":0,"url":"https://jargon.sh/user/unece/DigitalProductPassport/s/0/editor"}}
' validate-jargon-artefacts
```

### Result
``` bash
Validating Jargon artefacts...
Json Schemas: [{"fileName":"unece_DigitalProductPassport_DigitalProductPassport_jsonSchema.json","url":"https://jargon.sh/user/unece/DigitalProductPassport/s/0/artefacts/jsonSchemas/DigitalProductPassport.json?class=DigitalProductPassport"},{"fileName":"unece_DigitalProductPassport_DigitalProductPassport_instance_jsonSchema.json","url":"https://jargon.sh/user/unece/DigitalProductPassport/s/0/artefacts/jsonSchemas/DigitalProductPassport_instance.json?class=DigitalProductPassport_instance"},{"fileName":"unece_DigitalProductPassport_ProductPassport_jsonSchema.json","url":"https://jargon.sh/user/unece/DigitalProductPassport/s/0/artefacts/jsonSchemas/ProductPassport.json?class=ProductPassport"},{"fileName":"unece_DigitalProductPassport_ProductPassport_instance_jsonSchema.json","url":"https://jargon.sh/user/unece/DigitalProductPassport/s/0/artefacts/jsonSchemas/ProductPassport_instance.json?class=ProductPassport_instance"}]
Validating sample credentials against schemas...
Schemas: {"unece_DigitalProductPassport_DigitalProductPassport_jsonSchema.json":"https://jargon.sh/user/unece/DigitalProductPassport/s/0/artefacts/jsonSchemas/DigitalProductPassport.json?class=DigitalProductPassport","unece_DigitalProductPassport_ProductPassport_jsonSchema.json":"https://jargon.sh/user/unece/DigitalProductPassport/s/0/artefacts/jsonSchemas/ProductPassport.json?class=ProductPassport"}
Instances: {"unece_DigitalProductPassport_DigitalProductPassport_instance_jsonSchema.json":"https://jargon.sh/user/unece/DigitalProductPassport/s/0/artefacts/jsonSchemas/DigitalProductPassport_instance.json?class=DigitalProductPassport_instance","unece_DigitalProductPassport_ProductPassport_instance_jsonSchema.json":"https://jargon.sh/user/unece/DigitalProductPassport/s/0/artefacts/jsonSchemas/ProductPassport_instance.json?class=ProductPassport_instance"}

Fetched schema "unece_DigitalProductPassport_ProductPassport_jsonSchema.json" and instance "unece_DigitalProductPassport_ProductPassport_instance_jsonSchema.json".
Fetched schema "unece_DigitalProductPassport_DigitalProductPassport_jsonSchema.json" and instance "unece_DigitalProductPassport_DigitalProductPassport_instance_jsonSchema.json".
Validating sample credential "unece_DigitalProductPassport_DigitalProductPassport_instance_jsonSchema.json" against schema "unece_DigitalProductPassport_DigitalProductPassport_jsonSchema.json"
Sample credential "unece_DigitalProductPassport_DigitalProductPassport_instance_jsonSchema.json" validation result: passed.
Validating sample credential "unece_DigitalProductPassport_ProductPassport_instance_jsonSchema.json" against schema "unece_DigitalProductPassport_ProductPassport_jsonSchema.json"
Sample credential "unece_DigitalProductPassport_ProductPassport_instance_jsonSchema.json" validation result: passed.
All sample credentials validation result: passed.
Sample cretidentials against schemas validation complete.
Validating context in credentials...
Validating "https://jargon.sh/user/unece/DigitalProductPassport/s/0/artefacts/jsonSchemas/DigitalProductPassport_instance.json?class=DigitalProductPassport_instance"
::error::Error validating context in credentials: {"name":"jsonld.ValidationError","details":{"event":{"type":["JsonLdEvent"],"code":"relative object reference","level":"warning","message":"Relative object reference found.","details":{"object":"https://vocabulary.uncefact.org/CountryIdEnumeration Value"}}}}
Context in credentials validation results: failed.
Context in credentials validation complete.


Json LD context: {"fileName":"unece_DigitalProductPassport_jsonldContext.json","url":"https://jargon.sh/user/unece/DigitalProductPassport/s/0/artefacts/jsonldContexts/DigitalProductPassport.jsonld?class=DigitalProductPassport"}
Validating context...
Context validation results: passed.
Context validation complete.
{
  "validateCredentialsResult": {
    "valid": true
  },
  "validateContextInCredentialResult": {
    "valid": false
  },
  "validateContextResult": {
    "valid": true
  }
}

::set-output name=validation-result::Failed
::error::One or more Jargon artefact validations reported a failure. Please check the logs for details.
```