### PR TITLE
Sync the released 0.6.0 schemas, instances and vocabs.

### DIFF
--- a/data-models/untp-core/artefacts/context.jsonld
+++ b/data-models/untp-core/artefacts/context.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-core": "https://test.uncefact.org/vocabulary/untp/core/working/",
+    "untp-core": "https://test.uncefact.org/vocabulary/untp/core/0/",
     "geojson": "https://purl.org/geojson/vocab#",
     "renderMethodPrefix": "https://w3id.org/vc/render-method#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
@@ -526,7 +526,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/conformityTopicCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/conformityTopicCode#"
           }
         },
         "status": {
@@ -534,7 +534,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/statusCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/statusCode#"
           }
         },
         "subCriterion": {
@@ -657,7 +657,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/conformityTopicCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/conformityTopicCode#"
           }
         }
       }
@@ -730,7 +730,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/conformityTopicCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/conformityTopicCode#"
           }
         },
         "conformityEvidence": {
@@ -759,7 +759,7 @@
               "@type": "@vocab",
               "@context": {
                 "@protected": true,
-                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/hashMethodCode#"
+                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/hashMethodCode#"
               }
             },
             "encryptionMethod": {
@@ -767,7 +767,7 @@
               "@type": "@vocab",
               "@context": {
                 "@protected": true,
-                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/encryptionMethodCode#"
+                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/encryptionMethodCode#"
               }
             }
           }
@@ -848,7 +848,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/assessorLevelCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/assessorLevelCode#"
           }
         },
         "assessmentLevel": {
@@ -856,7 +856,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/assessmentLevelCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/assessmentLevelCode#"
           }
         },
         "attestationType": {
@@ -864,7 +864,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/attestationTypeCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/attestationTypeCode#"
           }
         },
         "issuedToParty": {
@@ -912,7 +912,7 @@
               "@type": "@vocab",
               "@context": {
                 "@protected": true,
-                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/hashMethodCode#"
+                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/hashMethodCode#"
               }
             },
             "encryptionMethod": {
@@ -920,7 +920,7 @@
               "@type": "@vocab",
               "@context": {
                 "@protected": true,
-                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/encryptionMethodCode#"
+                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/encryptionMethodCode#"
               }
             }
           }
@@ -951,7 +951,7 @@
               "@type": "@vocab",
               "@context": {
                 "@protected": true,
-                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/hashMethodCode#"
+                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/hashMethodCode#"
               }
             },
             "encryptionMethod": {
@@ -959,7 +959,7 @@
               "@type": "@vocab",
               "@context": {
                 "@protected": true,
-                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/encryptionMethodCode#"
+                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/encryptionMethodCode#"
               }
             }
           }

--- a/data-models/untp-core/vocabulary.jsonld
+++ b/data-models/untp-core/vocabulary.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-core": "https://test.uncefact.org/vocabulary/untp/core/working/",
+    "untp-core": "https://test.uncefact.org/vocabulary/untp/core/0/",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "owl": "http://www.w3.org/2002/07/owl#",

--- a/data-models/untp-dcc/artefacts/DigitalConformityCredential-instance.json
+++ b/data-models/untp-dcc/artefacts/DigitalConformityCredential-instance.json
@@ -5,7 +5,7 @@
   ],
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://test.uncefact.org/vocabulary/untp/dcc/working/"
+    "https://test.uncefact.org/vocabulary/untp/dcc/0.6.0/"
   ],
   "id": "https://example-company.com/credentials/2a423366-a0d6-4855-ba65-2e0c926d09b0",
   "issuer": {

--- a/data-models/untp-dcc/artefacts/DigitalConformityCredential-schema.json
+++ b/data-models/untp-dcc/artefacts/DigitalConformityCredential-schema.json
@@ -31,7 +31,7 @@
     "@context": {
       "example": [
         "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dcc/working/"
+        "https://test.uncefact.org/vocabulary/untp/dcc/0.6.0/"
       ],
       "type": "array",
       "items": {
@@ -45,13 +45,13 @@
           "type": "string"
         },
         {
-          "const": "https://test.uncefact.org/vocabulary/untp/dcc/working/",
+          "const": "https://test.uncefact.org/vocabulary/untp/dcc/0.6.0/",
           "type": "string"
         }
       ],
       "default": [
         "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dcc/working/"
+        "https://test.uncefact.org/vocabulary/untp/dcc/0.6.0/"
       ],
       "minItems": 2,
       "uniqueItems": true

--- a/data-models/untp-dcc/artefacts/context.jsonld
+++ b/data-models/untp-dcc/artefacts/context.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-dcc": "https://test.uncefact.org/vocabulary/untp/dcc/working/",
+    "untp-dcc": "https://test.uncefact.org/vocabulary/untp/dcc/0/",
     "untp-core": "https://test.uncefact.org/vocabulary/untp/core/0/",
     "geojson": "https://purl.org/geojson/vocab#",
     "renderMethodPrefix": "https://w3id.org/vc/render-method#",

--- a/data-models/untp-dcc/vocabulary.jsonld
+++ b/data-models/untp-dcc/vocabulary.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-dcc": "https://test.uncefact.org/vocabulary/untp/dcc/working/",
+    "untp-dcc": "https://test.uncefact.org/vocabulary/untp/dcc/0/",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "owl": "http://www.w3.org/2002/07/owl#",

--- a/data-models/untp-dfr/artefacts/DigitalFacilityRecord-instance.json
+++ b/data-models/untp-dfr/artefacts/DigitalFacilityRecord-instance.json
@@ -5,7 +5,7 @@
   ],
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://test.uncefact.org/vocabulary/untp/dfr/working/"
+    "https://test.uncefact.org/vocabulary/untp/dfr/0.6.0/"
   ],
   "id": "https://example-company.com/credentials/2a423366-a0d6-4855-ba65-2e0c926d09b0",
   "issuer": {

--- a/data-models/untp-dfr/artefacts/DigitalFacilityRecord-schema.json
+++ b/data-models/untp-dfr/artefacts/DigitalFacilityRecord-schema.json
@@ -31,7 +31,7 @@
     "@context": {
       "example": [
         "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dfr/working/"
+        "https://test.uncefact.org/vocabulary/untp/dfr/0.6.0/"
       ],
       "type": "array",
       "items": {
@@ -45,13 +45,13 @@
           "type": "string"
         },
         {
-          "const": "https://test.uncefact.org/vocabulary/untp/dfr/working/",
+          "const": "https://test.uncefact.org/vocabulary/untp/dfr/0.6.0/",
           "type": "string"
         }
       ],
       "default": [
         "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dfr/working/"
+        "https://test.uncefact.org/vocabulary/untp/dfr/0.6.0/"
       ],
       "minItems": 2,
       "uniqueItems": true

--- a/data-models/untp-dfr/artefacts/context.jsonld
+++ b/data-models/untp-dfr/artefacts/context.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-dfr": "https://test.uncefact.org/vocabulary/untp/dfr/working/",
+    "untp-dfr": "https://test.uncefact.org/vocabulary/untp/dfr/0/",
     "untp-core": "https://test.uncefact.org/vocabulary/untp/core/0/",
     "geojson": "https://purl.org/geojson/vocab#",
     "renderMethodPrefix": "https://w3id.org/vc/render-method#",

--- a/data-models/untp-dfr/vocabulary.jsonld
+++ b/data-models/untp-dfr/vocabulary.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-dfr": "https://test.uncefact.org/vocabulary/untp/dfr/working/",
+    "untp-dfr": "https://test.uncefact.org/vocabulary/untp/dfr/0/",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "owl": "http://www.w3.org/2002/07/owl#",

--- a/data-models/untp-dia/artefacts/DigitalIdentityAnchor-instance.json
+++ b/data-models/untp-dia/artefacts/DigitalIdentityAnchor-instance.json
@@ -5,7 +5,7 @@
   ],
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://test.uncefact.org/vocabulary/untp/dia/working/"
+    "https://test.uncefact.org/vocabulary/untp/dia/0.6.0/"
   ],
   "id": "https://example-company.com/credentials/2a423366-a0d6-4855-ba65-2e0c926d09b0",
   "issuer": {

--- a/data-models/untp-dia/artefacts/DigitalIdentityAnchor-schema.json
+++ b/data-models/untp-dia/artefacts/DigitalIdentityAnchor-schema.json
@@ -31,7 +31,7 @@
     "@context": {
       "example": [
         "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dia/working/"
+        "https://test.uncefact.org/vocabulary/untp/dia/0.6.0/"
       ],
       "type": "array",
       "items": {
@@ -45,13 +45,13 @@
           "type": "string"
         },
         {
-          "const": "https://test.uncefact.org/vocabulary/untp/dia/working/",
+          "const": "https://test.uncefact.org/vocabulary/untp/dia/0.6.0/",
           "type": "string"
         }
       ],
       "default": [
         "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dia/working/"
+        "https://test.uncefact.org/vocabulary/untp/dia/0.6.0/"
       ],
       "minItems": 2,
       "uniqueItems": true

--- a/data-models/untp-dia/artefacts/context.jsonld
+++ b/data-models/untp-dia/artefacts/context.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-dia": "https://test.uncefact.org/vocabulary/untp/dia/working/",
+    "untp-dia": "https://test.uncefact.org/vocabulary/untp/dia/0/",
     "untp-core": "https://test.uncefact.org/vocabulary/untp/core/0/",
     "renderMethodPrefix": "https://w3id.org/vc/render-method#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
@@ -119,7 +119,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/dia/working/RegistryTypeCodeList#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/dia/0/RegistryTypeCodeList#"
           }
         },
         "registrationScopeList": {

--- a/data-models/untp-dia/vocabulary.jsonld
+++ b/data-models/untp-dia/vocabulary.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-dia": "https://test.uncefact.org/vocabulary/untp/dia/working/",
+    "untp-dia": "https://test.uncefact.org/vocabulary/untp/dia/0/",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "owl": "http://www.w3.org/2002/07/owl#",

--- a/data-models/untp-dpp/artefacts/DigitalProductPassport-instance.json
+++ b/data-models/untp-dpp/artefacts/DigitalProductPassport-instance.json
@@ -5,7 +5,7 @@
   ],
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://test.uncefact.org/vocabulary/untp/dpp/working/"
+    "https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/"
   ],
   "id": "https://example-company.com/credentials/2a423366-a0d6-4855-ba65-2e0c926d09b0",
   "issuer": {

--- a/data-models/untp-dpp/artefacts/DigitalProductPassport-schema.json
+++ b/data-models/untp-dpp/artefacts/DigitalProductPassport-schema.json
@@ -31,7 +31,7 @@
     "@context": {
       "example": [
         "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dpp/working/"
+        "https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/"
       ],
       "type": "array",
       "items": {
@@ -45,13 +45,13 @@
           "type": "string"
         },
         {
-          "const": "https://test.uncefact.org/vocabulary/untp/dpp/working/",
+          "const": "https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/",
           "type": "string"
         }
       ],
       "default": [
         "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dpp/working/"
+        "https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/"
       ],
       "minItems": 2,
       "uniqueItems": true

--- a/data-models/untp-dpp/artefacts/context.jsonld
+++ b/data-models/untp-dpp/artefacts/context.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-dpp": "https://test.uncefact.org/vocabulary/untp/dpp/working/",
+    "untp-dpp": "https://test.uncefact.org/vocabulary/untp/dpp/0/",
     "untp-core": "https://test.uncefact.org/vocabulary/untp/core/0/",
     "geojson": "https://purl.org/geojson/vocab#",
     "renderMethodPrefix": "https://w3id.org/vc/render-method#",
@@ -720,7 +720,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/dpp/working/granularityCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/dpp/0/granularityCode#"
           }
         },
         "conformityClaim": {

--- a/data-models/untp-dpp/vocabulary.jsonld
+++ b/data-models/untp-dpp/vocabulary.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-dpp": "https://test.uncefact.org/vocabulary/untp/dpp/working/",
+    "untp-dpp": "https://test.uncefact.org/vocabulary/untp/dpp/0/",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "owl": "http://www.w3.org/2002/07/owl#",

--- a/data-models/untp-dte/artefacts/DigitalTraceabilityEvent-instance.json
+++ b/data-models/untp-dte/artefacts/DigitalTraceabilityEvent-instance.json
@@ -6,7 +6,7 @@
   "id": "https://example-company.com/credentials/2a423366-a0d6-4855-ba65-2e0c926d09b0",
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://test.uncefact.org/vocabulary/untp/dte/working/"
+    "https://test.uncefact.org/vocabulary/untp/dte/0.6.0/"
   ],
   "issuer": {
     "type": [

--- a/data-models/untp-dte/artefacts/DigitalTraceabilityEvent-schema.json
+++ b/data-models/untp-dte/artefacts/DigitalTraceabilityEvent-schema.json
@@ -37,7 +37,7 @@
     "@context": {
       "example": [
         "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dte/working/"
+        "https://test.uncefact.org/vocabulary/untp/dte/0.6.0/"
       ],
       "type": "array",
       "items": {
@@ -51,13 +51,13 @@
           "type": "string"
         },
         {
-          "const": "https://test.uncefact.org/vocabulary/untp/dte/working/",
+          "const": "https://test.uncefact.org/vocabulary/untp/dte/0.6.0/",
           "type": "string"
         }
       ],
       "default": [
         "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dte/working/"
+        "https://test.uncefact.org/vocabulary/untp/dte/0.6.0/"
       ],
       "minItems": 2,
       "uniqueItems": true

--- a/data-models/untp-dte/artefacts/context.jsonld
+++ b/data-models/untp-dte/artefacts/context.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-dte": "https://test.uncefact.org/vocabulary/untp/dte/working/",
+    "untp-dte": "https://test.uncefact.org/vocabulary/untp/dte/0/",
     "untp-core": "https://test.uncefact.org/vocabulary/untp/core/0/",
     "geojson": "https://purl.org/geojson/vocab#",
     "renderMethodPrefix": "https://w3id.org/vc/render-method#",
@@ -124,7 +124,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/working/actionCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/0/actionCode#"
           }
         },
         "disposition": {
@@ -579,7 +579,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/working/actionCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/0/actionCode#"
           }
         },
         "disposition": {
@@ -737,7 +737,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/working/actionCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/0/actionCode#"
           }
         },
         "disposition": {
@@ -864,7 +864,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/working/actionCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/0/actionCode#"
           }
         },
         "disposition": {
@@ -995,7 +995,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/working/actionCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/0/actionCode#"
           }
         },
         "disposition": {
@@ -1138,7 +1138,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/working/actionCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/0/actionCode#"
           }
         },
         "disposition": {

--- a/data-models/untp-dte/vocabulary.jsonld
+++ b/data-models/untp-dte/vocabulary.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-dte": "https://test.uncefact.org/vocabulary/untp/dte/working/",
+    "untp-dte": "https://test.uncefact.org/vocabulary/untp/dte/0/",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "owl": "http://www.w3.org/2002/07/owl#",


### PR DESCRIPTION
With this change, there is no longer any references to `working` within the data.

We currently only have `onSnapshot` syncs of data to the data-models-staging branch, so when we released 0.6.0, although Jargon then created the correct artefacts (and our existing release process published those artefacts correctly), the data-models-staging branch is not (currently) updated with the release changes.

So this PR just manually syncs the released artefacts to the data-models-staging branch before we merge that branch into main and re-sync it to HEAD to start the next snapshots for the next release.