### PR TITLE
fix: account for objects in context

### DIFF
--- a/.github/actions/validate-jargon-artefacts/src/contextValidation.js
+++ b/.github/actions/validate-jargon-artefacts/src/contextValidation.js
@@ -58,12 +58,14 @@ async function validateContextInCredential(rawArtefactData, jsonldContext) {
     if (instanceJson && jsonldContext && JARGON_CONTEXT_IRI_PREFIX) {
       const context = instanceJson['@context'];
 
-      if(context && Array.isArray(context) && jsonldContext.url) {
-      // Replace the deployed @context IRI (that is, the eventual IRI at which the context will be
-      // published when the deploy completes) with the Jargon context IRI where we know
-      // it is published right now.
-      instanceJson['@context'] = context.map(c =>
-          c.startsWith(JARGON_CONTEXT_IRI_PREFIX) ? jsonldContext.url : c
+      if (context && Array.isArray(context) && jsonldContext.url) {
+        // Replace the deployed @context IRI (that is, the eventual IRI at which the context will be
+        // published when the deploy completes) with the Jargon context IRI where we know
+        // it is published right now.
+        instanceJson['@context'] = context.map(c =>
+          typeof c === 'string' && c.startsWith(JARGON_CONTEXT_IRI_PREFIX)
+            ? jsonldContext.url
+            : c
         );
       }
     }


### PR DESCRIPTION
This PR resolves an issue in the [artifact validation action](https://github.com/uncefact/spec-untp/tree/main/.github/actions/validate-jargon-artefacts), where the action crashes if the context array of the sample instance being validated contains an object (see this [workflow run](https://github.com/uncefact/spec-untp/actions/runs/15153318094/job/42603315863)).

I’ve added a type guard to check if the value is a string. If it is, the transformation proceeds (as described in PR #359); otherwise, the transformation is skipped.

### Example

#### Validation command

``` bash
docker run --rm -e INPUT_JARGON-WEBHOOK-PAYLOAD='{"action":{"name":"onSnapshot","type":"snapshot"},"artefacts":{"dataModel":{"fileName":"unece_SustainabilityVocabulary_dataModel.svg","url":"https://jargon.sh/user/unece/SustainabilityVocabulary/s/19/artefacts/diagram/render.svg?light=true"},"jsonSchemas":[{"fileName":"unece_SustainabilityVocabulary_ConformitySchemeVocabulary_jsonSchema.json","url":"https://jargon.sh/user/unece/SustainabilityVocabulary/s/19/artefacts/jsonSchemas/ConformitySchemeVocabulary.json?class=ConformitySchemeVocabulary"},{"fileName":"unece_SustainabilityVocabulary_ConformitySchemeVocabulary_instance_jsonSchema.json","url":"https://jargon.sh/user/unece/SustainabilityVocabulary/s/19/artefacts/jsonSchemas/ConformitySchemeVocabulary_instance.json?class=ConformitySchemeVocabulary_instance"}],"jsonldContext":{"fileName":"unece_SustainabilityVocabulary_jsonldContext.json","url":"https://jargon.sh/user/unece/SustainabilityVocabulary/s/19/artefacts/jsonldContexts/SustainabilityVocabulary.jsonld?class=SustainabilityVocabulary"},"jsonldVocab":{"fileName":"unece_SustainabilityVocabulary_jsonld.json","url":"https://jargon.sh/user/unece/SustainabilityVocabulary/s/19/artefacts/jsonld/render.jsonld"},"readme":{"fileName":"unece_SustainabilityVocabulary_readme.md","url":"https://jargon.sh/user/unece/SustainabilityVocabulary/s/19/artefacts/readme/render.md"}},"domain":{"account":"unece","name":"SustainabilityVocabulary","url":"https://jargon.sh/user/unece/SustainabilityVocabulary"},"settings":{"jsonld":{"generate":true,"prefix":"untp-svc","uri":"[https://test.uncefact.org/vocabulary/untp/svc/{{version}}/](https://test.uncefact.org/vocabulary/untp/svc/%7B%7Bversion%7D%7D/)"}},"snapshot":{"description":"Update `ConformitySchemeVocabulary` to HAVE-A core `ConformityScheme` rather than including the properties explicitly.","index":19,"url":"https://jargon.sh/user/unece/SustainabilityVocabulary/s/19/editor"}}' validate-jargon-artefacts
```


#### Result

``` bash
Jargon artefact payload: {"action":{"name":"onSnapshot","type":"snapshot"},"artefacts":{"dataModel":{"fileName":"unece_SustainabilityVocabulary_dataModel.svg","url":"https://jargon.sh/user/unece/SustainabilityVocabulary/s/19/artefacts/diagram/render.svg?light=true"},"jsonSchemas":[{"fileName":"unece_SustainabilityVocabulary_ConformitySchemeVocabulary_jsonSchema.json","url":"https://jargon.sh/user/unece/SustainabilityVocabulary/s/19/artefacts/jsonSchemas/ConformitySchemeVocabulary.json?class=ConformitySchemeVocabulary"},{"fileName":"unece_SustainabilityVocabulary_ConformitySchemeVocabulary_instance_jsonSchema.json","url":"https://jargon.sh/user/unece/SustainabilityVocabulary/s/19/artefacts/jsonSchemas/ConformitySchemeVocabulary_instance.json?class=ConformitySchemeVocabulary_instance"}],"jsonldContext":{"fileName":"unece_SustainabilityVocabulary_jsonldContext.json","url":"https://jargon.sh/user/unece/SustainabilityVocabulary/s/19/artefacts/jsonldContexts/SustainabilityVocabulary.jsonld?class=SustainabilityVocabulary"},"jsonldVocab":{"fileName":"unece_SustainabilityVocabulary_jsonld.json","url":"https://jargon.sh/user/unece/SustainabilityVocabulary/s/19/artefacts/jsonld/render.jsonld"},"readme":{"fileName":"unece_SustainabilityVocabulary_readme.md","url":"https://jargon.sh/user/unece/SustainabilityVocabulary/s/19/artefacts/readme/render.md"}},"domain":{"account":"unece","name":"SustainabilityVocabulary","url":"https://jargon.sh/user/unece/SustainabilityVocabulary"},"settings":{"jsonld":{"generate":true,"prefix":"untp-svc","uri":"https://test.uncefact.org/vocabulary/untp/svc/{{version}}/"}},"snapshot":{"description":"Update `ConformitySchemeVocabulary` to HAVE-A core `ConformityScheme` rather than including the properties explicitly.","index":19,"url":"https://jargon.sh/user/unece/SustainabilityVocabulary/s/19/editor"}}
Validating Jargon artefacts...
Json Schemas: [{"fileName":"unece_SustainabilityVocabulary_ConformitySchemeVocabulary_jsonSchema.json","url":"https://jargon.sh/user/unece/SustainabilityVocabulary/s/19/artefacts/jsonSchemas/ConformitySchemeVocabulary.json?class=ConformitySchemeVocabulary"},{"fileName":"unece_SustainabilityVocabulary_ConformitySchemeVocabulary_instance_jsonSchema.json","url":"https://jargon.sh/user/unece/SustainabilityVocabulary/s/19/artefacts/jsonSchemas/ConformitySchemeVocabulary_instance.json?class=ConformitySchemeVocabulary_instance"}]
Validating sample credentials against schemas...
Schemas: {"unece_SustainabilityVocabulary_ConformitySchemeVocabulary_jsonSchema.json":"https://jargon.sh/user/unece/SustainabilityVocabulary/s/19/artefacts/jsonSchemas/ConformitySchemeVocabulary.json?class=ConformitySchemeVocabulary"}
Instances: {"unece_SustainabilityVocabulary_ConformitySchemeVocabulary_instance_jsonSchema.json":"https://jargon.sh/user/unece/SustainabilityVocabulary/s/19/artefacts/jsonSchemas/ConformitySchemeVocabulary_instance.json?class=ConformitySchemeVocabulary_instance"}

Fetched schema "unece_SustainabilityVocabulary_ConformitySchemeVocabulary_jsonSchema.json" and instance "unece_SustainabilityVocabulary_ConformitySchemeVocabulary_instance_jsonSchema.json".
Validating sample credential "unece_SustainabilityVocabulary_ConformitySchemeVocabulary_instance_jsonSchema.json" against schema "unece_SustainabilityVocabulary_ConformitySchemeVocabulary_jsonSchema.json"
Sample credential "unece_SustainabilityVocabulary_ConformitySchemeVocabulary_instance_jsonSchema.json" validation result: passed.
All sample credentials validation result: passed.
Sample cretidentials against schemas validation complete.
Validating context in credentials...
Validating "https://jargon.sh/user/unece/SustainabilityVocabulary/s/19/artefacts/jsonSchemas/ConformitySchemeVocabulary_instance.json?class=ConformitySchemeVocabulary_instance"
Context in credentials validation results: passed.
Context in credentials validation complete.


Json LD context: {"fileName":"unece_SustainabilityVocabulary_jsonldContext.json","url":"https://jargon.sh/user/unece/SustainabilityVocabulary/s/19/artefacts/jsonldContexts/SustainabilityVocabulary.jsonld?class=SustainabilityVocabulary"}
Validating context...
Context validation results: passed.
Context validation complete.
{
  "validateCredentialsResult": {
    "valid": true
  },
  "validateContextInCredentialResult": {
    "valid": true
  },
  "validateContextResult": {
    "valid": true
  }
}

::set-output name=validation-result::Passed

Jargon artefacts validation: Passed.
```