### PR TITLE
Add 0.6.1 released artefacts

### DIFF
--- a/data-models/untp-core/artefacts/context.jsonld
+++ b/data-models/untp-core/artefacts/context.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-core": "https://test.uncefact.org/vocabulary/untp/core/working/",
+    "untp-core": "https://test.uncefact.org/vocabulary/untp/core/0/",
     "schemaorg": "https://schema.org/",
     "geojson": "https://purl.org/geojson/vocab#",
     "renderMethodPrefix": "https://w3id.org/vc/render-method#",
@@ -593,7 +593,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/conformityTopicCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/conformityTopicCode#"
           }
         },
         "status": {
@@ -601,7 +601,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/statusCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/statusCode#"
           }
         },
         "subCriterion": {
@@ -731,7 +731,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/conformityTopicCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/conformityTopicCode#"
           }
         }
       }
@@ -807,7 +807,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/conformityTopicCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/conformityTopicCode#"
           }
         },
         "conformityEvidence": {
@@ -836,7 +836,7 @@
               "@type": "@vocab",
               "@context": {
                 "@protected": true,
-                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/hashMethodCode#"
+                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/hashMethodCode#"
               }
             },
             "encryptionMethod": {
@@ -844,7 +844,7 @@
               "@type": "@vocab",
               "@context": {
                 "@protected": true,
-                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/encryptionMethodCode#"
+                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/encryptionMethodCode#"
               }
             }
           }
@@ -934,7 +934,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/assessorLevelCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/assessorLevelCode#"
           }
         },
         "assessmentLevel": {
@@ -942,7 +942,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/assessmentLevelCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/assessmentLevelCode#"
           }
         },
         "attestationType": {
@@ -950,7 +950,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/attestationTypeCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/attestationTypeCode#"
           }
         },
         "description": {
@@ -1007,7 +1007,7 @@
               "@type": "@vocab",
               "@context": {
                 "@protected": true,
-                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/hashMethodCode#"
+                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/hashMethodCode#"
               }
             },
             "encryptionMethod": {
@@ -1015,7 +1015,7 @@
               "@type": "@vocab",
               "@context": {
                 "@protected": true,
-                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/encryptionMethodCode#"
+                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/encryptionMethodCode#"
               }
             }
           }
@@ -1046,7 +1046,7 @@
               "@type": "@vocab",
               "@context": {
                 "@protected": true,
-                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/hashMethodCode#"
+                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/hashMethodCode#"
               }
             },
             "encryptionMethod": {
@@ -1054,7 +1054,7 @@
               "@type": "@vocab",
               "@context": {
                 "@protected": true,
-                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/working/encryptionMethodCode#"
+                "@vocab": "https://test.uncefact.org/vocabulary/untp/core/0/encryptionMethodCode#"
               }
             }
           }

--- a/data-models/untp-core/vocabulary.jsonld
+++ b/data-models/untp-core/vocabulary.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-core": "https://test.uncefact.org/vocabulary/untp/core/working/",
+    "untp-core": "https://test.uncefact.org/vocabulary/untp/core/0/",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "owl": "http://www.w3.org/2002/07/owl#",

--- a/data-models/untp-dcc/artefacts/context.jsonld
+++ b/data-models/untp-dcc/artefacts/context.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-dcc": "https://test.uncefact.org/vocabulary/untp/dcc/working/",
+    "untp-dcc": "https://test.uncefact.org/vocabulary/untp/dcc/0/",
     "schemaorg": "https://schema.org/",
     "untp-core": "https://test.uncefact.org/vocabulary/untp/core/0/",
     "geojson": "https://purl.org/geojson/vocab#",

--- a/data-models/untp-dcc/artefacts/untp-dcc-instance.json
+++ b/data-models/untp-dcc/artefacts/untp-dcc-instance.json
@@ -5,7 +5,7 @@
   ],
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://test.uncefact.org/vocabulary/untp/dcc/working/"
+    "https://test.uncefact.org/vocabulary/untp/dcc/0.6.1/"
   ],
   "id": "https://example-company.com/credentials/2a423366-a0d6-4855-ba65-2e0c926d09b0",
   "issuer": {

--- a/data-models/untp-dcc/artefacts/untp-dcc-schema.json
+++ b/data-models/untp-dcc/artefacts/untp-dcc-schema.json
@@ -31,7 +31,7 @@
     "@context": {
       "example": [
         "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dcc/working/"
+        "https://test.uncefact.org/vocabulary/untp/dcc/0.6.1/"
       ],
       "type": "array",
       "items": {
@@ -45,13 +45,13 @@
           "type": "string"
         },
         {
-          "const": "https://test.uncefact.org/vocabulary/untp/dcc/working/",
+          "const": "https://test.uncefact.org/vocabulary/untp/dcc/0.6.1/",
           "type": "string"
         }
       ],
       "default": [
         "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dcc/working/"
+        "https://test.uncefact.org/vocabulary/untp/dcc/0.6.1/"
       ],
       "minItems": 2,
       "uniqueItems": true

--- a/data-models/untp-dcc/vocabulary.jsonld
+++ b/data-models/untp-dcc/vocabulary.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-dcc": "https://test.uncefact.org/vocabulary/untp/dcc/working/",
+    "untp-dcc": "https://test.uncefact.org/vocabulary/untp/dcc/0/",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "owl": "http://www.w3.org/2002/07/owl#",

--- a/data-models/untp-dfr/artefacts/context.jsonld
+++ b/data-models/untp-dfr/artefacts/context.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-dfr": "https://test.uncefact.org/vocabulary/untp/dfr/working/",
+    "untp-dfr": "https://test.uncefact.org/vocabulary/untp/dfr/0/",
     "schemaorg": "https://schema.org/",
     "untp-core": "https://test.uncefact.org/vocabulary/untp/core/0/",
     "geojson": "https://purl.org/geojson/vocab#",

--- a/data-models/untp-dfr/artefacts/untp-dfr-instance.json
+++ b/data-models/untp-dfr/artefacts/untp-dfr-instance.json
@@ -5,7 +5,7 @@
   ],
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://test.uncefact.org/vocabulary/untp/dfr/working/"
+    "https://test.uncefact.org/vocabulary/untp/dfr/0.6.1/"
   ],
   "id": "https://example-company.com/credentials/2a423366-a0d6-4855-ba65-2e0c926d09b0",
   "issuer": {

--- a/data-models/untp-dfr/artefacts/untp-dfr-schema.json
+++ b/data-models/untp-dfr/artefacts/untp-dfr-schema.json
@@ -31,7 +31,7 @@
     "@context": {
       "example": [
         "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dfr/working/"
+        "https://test.uncefact.org/vocabulary/untp/dfr/0.6.1/"
       ],
       "type": "array",
       "items": {
@@ -45,13 +45,13 @@
           "type": "string"
         },
         {
-          "const": "https://test.uncefact.org/vocabulary/untp/dfr/working/",
+          "const": "https://test.uncefact.org/vocabulary/untp/dfr/0.6.1/",
           "type": "string"
         }
       ],
       "default": [
         "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dfr/working/"
+        "https://test.uncefact.org/vocabulary/untp/dfr/0.6.1/"
       ],
       "minItems": 2,
       "uniqueItems": true

--- a/data-models/untp-dfr/vocabulary.jsonld
+++ b/data-models/untp-dfr/vocabulary.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-dfr": "https://test.uncefact.org/vocabulary/untp/dfr/working/",
+    "untp-dfr": "https://test.uncefact.org/vocabulary/untp/dfr/0/",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "owl": "http://www.w3.org/2002/07/owl#",

--- a/data-models/untp-dia/artefacts/context.jsonld
+++ b/data-models/untp-dia/artefacts/context.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-dia": "https://test.uncefact.org/vocabulary/untp/dia/working/",
+    "untp-dia": "https://test.uncefact.org/vocabulary/untp/dia/0/",
     "schemaorg": "https://schema.org/",
     "untp-core": "https://test.uncefact.org/vocabulary/untp/core/0/",
     "renderMethodPrefix": "https://w3id.org/vc/render-method#",
@@ -147,7 +147,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/dia/working/RegistryTypeCodeList#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/dia/0/RegistryTypeCodeList#"
           }
         },
         "registrationScopeList": {

--- a/data-models/untp-dia/artefacts/untp-dia-instance.json
+++ b/data-models/untp-dia/artefacts/untp-dia-instance.json
@@ -5,7 +5,7 @@
   ],
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://test.uncefact.org/vocabulary/untp/dia/working/"
+    "https://test.uncefact.org/vocabulary/untp/dia/0.6.1/"
   ],
   "id": "https://example-company.com/credentials/2a423366-a0d6-4855-ba65-2e0c926d09b0",
   "issuer": {

--- a/data-models/untp-dia/artefacts/untp-dia-schema.json
+++ b/data-models/untp-dia/artefacts/untp-dia-schema.json
@@ -31,7 +31,7 @@
     "@context": {
       "example": [
         "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dia/working/"
+        "https://test.uncefact.org/vocabulary/untp/dia/0.6.1/"
       ],
       "type": "array",
       "items": {
@@ -45,13 +45,13 @@
           "type": "string"
         },
         {
-          "const": "https://test.uncefact.org/vocabulary/untp/dia/working/",
+          "const": "https://test.uncefact.org/vocabulary/untp/dia/0.6.1/",
           "type": "string"
         }
       ],
       "default": [
         "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dia/working/"
+        "https://test.uncefact.org/vocabulary/untp/dia/0.6.1/"
       ],
       "minItems": 2,
       "uniqueItems": true

--- a/data-models/untp-dia/vocabulary.jsonld
+++ b/data-models/untp-dia/vocabulary.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-dia": "https://test.uncefact.org/vocabulary/untp/dia/working/",
+    "untp-dia": "https://test.uncefact.org/vocabulary/untp/dia/0/",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "owl": "http://www.w3.org/2002/07/owl#",

--- a/data-models/untp-dpp/artefacts/context.jsonld
+++ b/data-models/untp-dpp/artefacts/context.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-dpp": "https://test.uncefact.org/vocabulary/untp/dpp/working/",
+    "untp-dpp": "https://test.uncefact.org/vocabulary/untp/dpp/0/",
     "schemaorg": "https://schema.org/",
     "untp-core": "https://test.uncefact.org/vocabulary/untp/core/0/",
     "geojson": "https://purl.org/geojson/vocab#",
@@ -794,7 +794,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/dpp/working/granularityCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/dpp/0/granularityCode#"
           }
         },
         "conformityClaim": {

--- a/data-models/untp-dpp/artefacts/untp-dpp-instance.json
+++ b/data-models/untp-dpp/artefacts/untp-dpp-instance.json
@@ -5,7 +5,7 @@
   ],
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://test.uncefact.org/vocabulary/untp/dpp/working/"
+    "https://test.uncefact.org/vocabulary/untp/dpp/0.6.1/"
   ],
   "id": "https://example-company.com/credentials/2a423366-a0d6-4855-ba65-2e0c926d09b0",
   "issuer": {

--- a/data-models/untp-dpp/artefacts/untp-dpp-schema.json
+++ b/data-models/untp-dpp/artefacts/untp-dpp-schema.json
@@ -31,7 +31,7 @@
     "@context": {
       "example": [
         "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dpp/working/"
+        "https://test.uncefact.org/vocabulary/untp/dpp/0.6.1/"
       ],
       "type": "array",
       "items": {
@@ -45,13 +45,13 @@
           "type": "string"
         },
         {
-          "const": "https://test.uncefact.org/vocabulary/untp/dpp/working/",
+          "const": "https://test.uncefact.org/vocabulary/untp/dpp/0.6.1/",
           "type": "string"
         }
       ],
       "default": [
         "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dpp/working/"
+        "https://test.uncefact.org/vocabulary/untp/dpp/0.6.1/"
       ],
       "minItems": 2,
       "uniqueItems": true

--- a/data-models/untp-dpp/vocabulary.jsonld
+++ b/data-models/untp-dpp/vocabulary.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-dpp": "https://test.uncefact.org/vocabulary/untp/dpp/working/",
+    "untp-dpp": "https://test.uncefact.org/vocabulary/untp/dpp/0/",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "owl": "http://www.w3.org/2002/07/owl#",

--- a/data-models/untp-dte/artefacts/context.jsonld
+++ b/data-models/untp-dte/artefacts/context.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-dte": "https://test.uncefact.org/vocabulary/untp/dte/working/",
+    "untp-dte": "https://test.uncefact.org/vocabulary/untp/dte/0/",
     "untp-core": "https://test.uncefact.org/vocabulary/untp/core/0/",
     "schemaorg": "https://schema.org/",
     "geojson": "https://purl.org/geojson/vocab#",
@@ -155,7 +155,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/working/actionCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/0/actionCode#"
           }
         },
         "disposition": {
@@ -634,7 +634,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/working/actionCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/0/actionCode#"
           }
         },
         "disposition": {
@@ -790,7 +790,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/working/actionCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/0/actionCode#"
           }
         },
         "disposition": {
@@ -916,7 +916,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/working/actionCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/0/actionCode#"
           }
         },
         "disposition": {
@@ -1046,7 +1046,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/working/actionCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/0/actionCode#"
           }
         },
         "disposition": {
@@ -1188,7 +1188,7 @@
           "@type": "@vocab",
           "@context": {
             "@protected": true,
-            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/working/actionCode#"
+            "@vocab": "https://test.uncefact.org/vocabulary/untp/dte/0/actionCode#"
           }
         },
         "disposition": {

--- a/data-models/untp-dte/artefacts/untp-dte-instance.json
+++ b/data-models/untp-dte/artefacts/untp-dte-instance.json
@@ -6,7 +6,7 @@
   "id": "https://example-company.com/credentials/2a423366-a0d6-4855-ba65-2e0c926d09b0",
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://test.uncefact.org/vocabulary/untp/dte/working/"
+    "https://test.uncefact.org/vocabulary/untp/dte/0.6.1/"
   ],
   "issuer": {
     "type": [

--- a/data-models/untp-dte/artefacts/untp-dte-schema.json
+++ b/data-models/untp-dte/artefacts/untp-dte-schema.json
@@ -37,7 +37,7 @@
     "@context": {
       "example": [
         "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dte/working/"
+        "https://test.uncefact.org/vocabulary/untp/dte/0.6.1/"
       ],
       "type": "array",
       "items": {
@@ -51,13 +51,13 @@
           "type": "string"
         },
         {
-          "const": "https://test.uncefact.org/vocabulary/untp/dte/working/",
+          "const": "https://test.uncefact.org/vocabulary/untp/dte/0.6.1/",
           "type": "string"
         }
       ],
       "default": [
         "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dte/working/"
+        "https://test.uncefact.org/vocabulary/untp/dte/0.6.1/"
       ],
       "minItems": 2,
       "uniqueItems": true

--- a/data-models/untp-dte/vocabulary.jsonld
+++ b/data-models/untp-dte/vocabulary.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-dte": "https://test.uncefact.org/vocabulary/untp/dte/working/",
+    "untp-dte": "https://test.uncefact.org/vocabulary/untp/dte/0/",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "owl": "http://www.w3.org/2002/07/owl#",

--- a/data-models/untp-svc/artefacts/context.jsonld
+++ b/data-models/untp-svc/artefacts/context.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-svc": "https://test.uncefact.org/vocabulary/untp/svc/working/",
+    "untp-svc": "https://test.uncefact.org/vocabulary/untp/svc/0/",
     "untp-core": "https://test.uncefact.org/vocabulary/untp/core/0/",
     "schemaorg": "https://schema.org/",
     "xsd": "http://www.w3.org/2001/XMLSchema#",

--- a/data-models/untp-svc/artefacts/untp-svc-instance.json
+++ b/data-models/untp-svc/artefacts/untp-svc-instance.json
@@ -3,7 +3,7 @@
     "ConformitySchemeVocabulary"
   ],
   "@context": [
-    "https://test.uncefact.org/vocabulary/untp/svc/working/"
+    "https://test.uncefact.org/vocabulary/untp/svc/0.6.1/"
   ],
   "id": "https://sample-scheme.org/ESGStandard/v4.0",
   "scheme": {

--- a/data-models/untp-svc/vocabulary.jsonld
+++ b/data-models/untp-svc/vocabulary.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "untp-svc": "https://test.uncefact.org/vocabulary/untp/svc/working/",
+    "untp-svc": "https://test.uncefact.org/vocabulary/untp/svc/0/",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "owl": "http://www.w3.org/2002/07/owl#",


### PR DESCRIPTION
This PR just `curl`s the released artefacts from the Jargon releases to update the context links.

We have this situation because we create PRs with changes on Jargon snapshots, but not on Jargon releases.

I think we mentioned this during the call the other week, but we'd need to create PRs on a Jargon release as well, to capture these when the Jargon release is done, rather than manually `curl`ing them. Is that right @kshychko ?