### PR TITLE
feat: pass image size to carousel

### DIFF
--- a/website/src/components/Pledges/index.tsx
+++ b/website/src/components/Pledges/index.tsx
@@ -26,6 +26,7 @@ const Pledges: FC<PledgesProps> = ({
                   src={impl.logo}
                   alt={`${impl.name} logo`}
                   className={styles.implementationLogo}
+                  style={impl.imageStyle}
                 />
               </a>
             </div>

--- a/website/src/types/index.ts
+++ b/website/src/types/index.ts
@@ -2,4 +2,8 @@ export interface Implementation {
   name: string;
   link: string;
   logo: string;
+  imageStyle?: {
+    width?: string;
+    height?: string;
+  };
 }


### PR DESCRIPTION
This PR extends the `Implementations` interface to include image size, which the Pledges carousel then consumes.

This addresses an issue where SVGs inherently lack a size, resulting in a size of 0x0px and avoids placing a constraint on other logos displayed that don't share the same aspect ratio.

Rendering of an SVG

**Before the fix**
<img width="1673" alt="Screenshot 2025-06-24 at 1 25 57 pm" src="https://github.com/user-attachments/assets/500fcbc0-57e3-4052-927d-d131209cd670" />

**After the fix**
<img width="1491" alt="Screenshot 2025-06-24 at 1 09 20 pm" src="https://github.com/user-attachments/assets/3b8d8466-5792-4431-93f5-2130d341e26b" />
