### PR TITLE
feat: run validation for PRs with main as a base

### DIFF
--- a/.github/workflows/data-models-snapshot.yml
+++ b/.github/workflows/data-models-snapshot.yml
@@ -3,7 +3,7 @@ name: Publish data models snapshots
 on:
   push:
     branches:
-      - 'data-models-staging'
+      - 'main'
     paths:
       - 'data-models/**'
 

--- a/.github/workflows/jargon-release.yml
+++ b/.github/workflows/jargon-release.yml
@@ -5,6 +5,6 @@ on:
     types: [ 'jargon_onRelease' ]
 
 jobs:
-  jargon_snapshot:
+  jargon_release:
     uses: uncefact/.github/.github/workflows/untp-jargon-release.yml@main
     secrets: inherit

--- a/.github/workflows/validate-jargon-artefacts.yml
+++ b/.github/workflows/validate-jargon-artefacts.yml
@@ -3,7 +3,7 @@ name: Validate Jargon Artefacts
 on:
   pull_request:
     branches:
-      - 'data-models-staging'
+      - 'main'
     paths:
       - 'data-models/**'
   workflow_dispatch:
@@ -15,13 +15,23 @@ jobs:
     steps:
 
       - uses: actions/checkout@v4
-      - name: Download client payload
+
+      - name: Download snapshot payload
+        if: startsWith( github.head_ref, 'feature/jargon-sync-' )
         run: |
           branch_name="${{ github.head_ref }}"
           gh run download -n client-payload-${branch_name#*sync-}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
+      - name: Download release payload
+        if: startsWith( github.head_ref, 'feature/jargon-release-' )
+        run: |
+          branch_name="${{ github.head_ref }}"
+          gh run download -n client-payload-${branch_name#*release-}
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Read file and set env variable
         run: |
           echo "CLIENT_PAYLOAD<<EOF" >> $GITHUB_ENV
@@ -32,3 +42,8 @@ jobs:
         uses: ./.github/actions/validate-jargon-artefacts
         with:
           jargon-webhook-payload: ${{ env.CLIENT_PAYLOAD }}
+
+  validate-jargon-release-artefacts:
+    if: startsWith( github.head_ref, 'feature/jargon-release-' )
+    uses: uncefact/.github/.github/workflows/untp-validate-jargon-release.yml@main
+    secrets: inherit


### PR DESCRIPTION
This PR updates workflows to be triggered for PRs with main branch as a base instead of data-models-staging.
It also adds an additional job to validate artefacts if the PR is a release one.